### PR TITLE
feat: support custom ua

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Special" = "特殊";
 "Random Device Identity" = "随机设备身份";
 "Hide MNGA Meta" = "隐藏 MNGA Meta 版块";
+"Custom" = "自定义";
 
 "Missing Field" = "缺少字段";
 "Network Connection" = "网络连接";

--- a/app/Shared/Protos/Extensions.swift
+++ b/app/Shared/Protos/Extensions.swift
@@ -75,6 +75,10 @@ extension Device {
       return "Android"
     case .desktop:
       return "Desktop"
+    case .windowsPhone:
+      return "Windows Phone"
+    case .custom:
+      return "Custom"
     default:
       return "Unknown"
     }
@@ -86,6 +90,12 @@ extension Device {
       return "applelogo"
     case .android:
       return "candybarphone"
+    case .desktop:
+      return "pc"
+    case .windowsPhone:
+      return "flipphone"
+    case .custom:
+      return "questionmark.square.dashed"
     default:
       return "pc"
     }

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -137,9 +137,16 @@ struct PreferencesInnerView: View {
       }
     }.lineLimit(1)
 
-    Picker(selection: $pref.requestOption.device, label: Label("Device Identity", systemImage: "ipad.and.iphone")) {
-      ForEach(Device.allCases, id: \.self) { device in
-        Label(device.description, systemImage: device.icon).tag(device)
+    Group {
+      Picker(selection: $pref.requestOption.device.animation(), label: Label("Device Identity", systemImage: "ipad.and.iphone")) {
+        ForEach(Device.allCases, id: \.self) { device in
+          Label(device.description, systemImage: device.icon).tag(device)
+        }
+      }
+
+      if pref.requestOption.device == .custom, !pref.requestOption.randomUa {
+        TextField("Custom User Agent", text: $pref.requestOption.customUa)
+          .autocorrectionDisabled(true)
       }
     }.disabled(pref.requestOption.randomUa)
   }
@@ -158,7 +165,7 @@ struct PreferencesInnerView: View {
         Label("Auto Open in Browser when Banned", systemImage: "network")
       }
 
-      Toggle(isOn: $pref.requestOption.randomUa) {
+      Toggle(isOn: $pref.requestOption.randomUa.animation()) {
         Label("Random Device Identity", systemImage: "ipad.and.iphone")
       }
     }

--- a/logic/service/src/constants.rs
+++ b/logic/service/src/constants.rs
@@ -4,10 +4,13 @@ pub const DEFAULT_BASE_URL: &str = "https://nga.178.com";
 pub const DEFAULT_MOCK_BASE_URL: &str = "https://bugenzhao.com/MNGA/api";
 pub const FORUM_ICON_PATH: &str = "http://img4.ngacn.cc/ngabbs/nga_classic/f/app/";
 pub const MNGA_ICON_PATH: &str = "https://raw.githubusercontent.com/BugenZhao/MNGA/main/app/Shared/Assets.xcassets/RoundedIcon.imageset/RoundedIcon-Mac.png";
+
 pub const SUCCESS_MSGS: &[&str] = &["完毕", "没有符合条件的结果", "今天已经签到"];
+
 pub const APPLE_UA: &str = "NGA_skull/7.3.1(iPhone13,2;iOS 15.5)";
 pub const ANDROID_UA: &str = "Nga_Official/80024(Android12)";
 pub const DESKTOP_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36";
+pub const WINDOWS_PHONE_UA: &str = "NGA_WP_JW/(;WINDOWS)";
 
 #[cfg(test)]
 pub const REVIEW_UID: &str = "62650766";

--- a/logic/service/src/fetch.rs
+++ b/logic/service/src/fetch.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, time::Duration};
 
 use crate::{
     auth,
-    constants::{ANDROID_UA, APPLE_UA, DESKTOP_UA},
+    constants::{ANDROID_UA, APPLE_UA, DESKTOP_UA, WINDOWS_PHONE_UA},
     error::{ServiceError, ServiceResult},
     request,
     utils::extract_error,
@@ -23,6 +23,9 @@ fn device_ua() -> Cow<'static, str> {
             Device::DESKTOP => DESKTOP_UA,
             Device::APPLE => APPLE_UA,
             Device::ANDROID => ANDROID_UA,
+            Device::WINDOWS_PHONE => WINDOWS_PHONE_UA,
+            // Use `custom_ua` if `device` is `CUSTOM`
+            Device::CUSTOM => return option.get_custom_ua().to_owned().into(),
         }
         .into()
     }

--- a/logic/service/src/request.rs
+++ b/logic/service/src/request.rs
@@ -10,6 +10,7 @@ fn default_request_option() -> RequestOption {
         device: Device::APPLE,
         mock_base_url_v2: DEFAULT_MOCK_BASE_URL.to_owned(),
         random_ua: false,
+        custom_ua: "".to_owned(),
         ..Default::default()
     }
 }

--- a/protos/DataModel.proto
+++ b/protos/DataModel.proto
@@ -55,6 +55,8 @@ enum Device {
   APPLE = 0; // From official NGA iOS App or MNGA (by default).
   ANDROID = 1;
   DESKTOP = 2;
+  WINDOWS_PHONE = 3;
+  CUSTOM = 100; // Used for custom User-Agent.
 }
 
 message Post {
@@ -169,6 +171,8 @@ message RequestOption {
   Device device = 2;
   string mock_base_url_v2 = 3;
   bool random_ua = 4;
+  string custom_ua = 5; // Only used when `device` is `CUSTOM` and `random_ua`
+                        // is false.
 }
 
 enum VoteState {


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

This PR adds a user-agent from the Windows UWP client and supports customizing the user-agent, as a workaround for #126.