### PR TITLE
feat(ui): add option for larger font in post

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -211,9 +211,9 @@
 "Detailed" = "详细";
 "Time Ago" = "时间差";
 "Topic List Style" = "话题列表样式";
-"Topic Details Style" = "话题详情样式";
+"Topic Details Style" = "话题内容样式";
 "Author Info" = "作者信息";
-"Show Author Indicator" = "显示作者图标";
+"Show Author Indicator" = "显示作者标识";
 "Mode" = "模式";
 "Participants" = "参与者";
 "List Style" = "列表样式";
@@ -228,6 +228,9 @@
 "Hide MNGA Meta" = "隐藏 MNGA Meta 版块";
 "Custom" = "自定义";
 "Custom User-Agent" = "自定义 User-Agent";
+"Tag" = "标签";
+"Add Tag" = "添加标签";
+"Larger Font" = "更大字体";
 
 "Missing Field" = "缺少字段";
 "Network Connection" = "网络连接";
@@ -237,5 +240,3 @@
 "Text Parse" = "文本解析";
 "URL Parse" = "URL 解析";
 "Backend Panic" = "后端错误";
-"Tag" = "标签";
-"Add Tag" = "添加标签";

--- a/app/Shared/Storage/PreferencesStorage.swift
+++ b/app/Shared/Storage/PreferencesStorage.swift
@@ -38,6 +38,7 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("postRowShowUserRegDate") var postRowShowUserRegDate = false
   @AppStorage("postRowDateTimeStrategy") var postRowDateTimeStrategy = DateTimeTextView.Strategy.automatic
   @AppStorage("postRowShowAuthorIndicator") var postRowShowAuthorIndicator = true
+  @AppStorage("postRowLargerFont") var postRowLargerFont = false
 
   @AppStorage("autoOpenInBrowserWhenBanned") var autoOpenInBrowserWhenBanned = true
 

--- a/app/Shared/Utilities/ContentCombiner.swift
+++ b/app/Shared/Utilities/ContentCombiner.swift
@@ -379,7 +379,11 @@ class ContentCombiner {
   }
 
   private func visit(quote: Span.Tagged) {
-    let combiner = ContentCombiner(parent: self, font: { _ in Font.subheadline }, color: { _ in Color.primary.opacity(0.9) })
+    let combiner = ContentCombiner(
+      parent: self,
+      font: { $0 == .callout ? .subheadline : .callout },
+      color: { _ in Color.primary.opacity(0.9) }
+    )
     combiner.inQuote = true
 
     let spans = quote.spans

--- a/app/Shared/Views/PostCommentRowView.swift
+++ b/app/Shared/Views/PostCommentRowView.swift
@@ -35,7 +35,7 @@ struct PostCommentRowView: View {
   @ViewBuilder
   var content: some View {
     QuoteView(fullWidth: false) {
-      PostContentView(spans: realSpans, defaultFont: .subheadline, initialInQuote: true)
+      PostContentView(spans: realSpans, fontSize: .small, initialInQuote: true)
     }
   }
 

--- a/app/Shared/Views/PostContentView.swift
+++ b/app/Shared/Views/PostContentView.swift
@@ -21,21 +21,42 @@ extension EnvironmentValues {
   }
 }
 
+enum PostFontSize {
+  // Used in posts.
+  case small
+  // Used in post comments and signatures.
+  // Though the code path is not unified yet, this will also be used for quotes.
+  case normal
+}
+
 struct PostContentView<S: Sequence & Equatable>: View where S.Element == Span {
+  @StateObject var pref = PreferencesStorage.shared
+
   let spans: S
   let error: String?
   let id: PostId?
   let postDate: UInt64?
-  let defaultFont: Font
+  let fontSize: PostFontSize
   let defaultColor: Color
   let initialInQuote: Bool
 
-  init(spans: S, error: String? = nil, id: PostId? = nil, postDate: UInt64? = nil, defaultFont: Font = .callout, defaultColor: Color = .primary, initialInQuote: Bool = false) {
+  var defaultFont: Font {
+    let useLargerFont = pref.postRowLargerFont
+
+    return switch fontSize {
+    case .small:
+      useLargerFont ? .callout : .subheadline
+    case .normal:
+      useLargerFont ? .body : .callout
+    }
+  }
+
+  init(spans: S, error: String? = nil, id: PostId? = nil, postDate: UInt64? = nil, fontSize: PostFontSize = .normal, defaultColor: Color = .primary, initialInQuote: Bool = false) {
     self.spans = spans
     self.error = error
     self.id = id
     self.postDate = postDate
-    self.defaultFont = defaultFont
+    self.fontSize = fontSize
     self.defaultColor = defaultColor
     self.initialInQuote = initialInQuote
   }
@@ -67,13 +88,12 @@ struct PostContentView<S: Sequence & Equatable>: View where S.Element == Span {
 }
 
 extension PostContentView where S == [Span] {
-  // TODO: shall we increase default font size?
-  init(content: PostContent, id: PostId? = nil, postDate: UInt64? = nil, defaultFont: Font = .callout, defaultColor: Color = .primary, initialInQuote: Bool = false) {
+  init(content: PostContent, id: PostId? = nil, postDate: UInt64? = nil, fontSize: PostFontSize = .normal, defaultColor: Color = .primary, initialInQuote: Bool = false) {
     spans = content.spans
     error = content.error
     self.id = id
     self.postDate = postDate
-    self.defaultFont = defaultFont
+    self.fontSize = fontSize
     self.defaultColor = defaultColor
     self.initialInQuote = initialInQuote
   }

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -15,6 +15,19 @@ private struct PostRowAppearanceView: View {
     Form {
       Section(header: Text("Preview")) {
         PostRowView.build(post: .dummy, isAuthor: true, vote: .constant((state: .up, delta: 0)))
+          // PostContentView doesn't seem to correctly refresh when larger font setting changes,
+          // as it creates a new state object from the global shared one. This won't be a problem
+          // in actual browsing. So here we simply use a trick to force refresh.
+          .id("dummy-post-larger-font-\(pref.postRowLargerFont)")
+      }
+
+      Section {
+        Toggle(isOn: $pref.usePaginatedDetails) {
+          Label("Paginated Reading", systemImage: "square.stack")
+        }
+        Toggle(isOn: $pref.postRowLargerFont) {
+          Label("Larger Font", systemImage: "textformat.size")
+        }
       }
 
       Section {
@@ -36,27 +49,20 @@ private struct PostRowAppearanceView: View {
         Toggle(isOn: $pref.showAvatar.animation()) {
           Label("Show Avatar", systemImage: "person.crop.circle")
         }
-      }
 
-      Section {
         Toggle(isOn: $pref.postRowShowAuthorIndicator.animation()) {
-          Text("Show Author Indicator")
+          Label("Show Author Indicator", systemImage: "person.fill")
         }
         Toggle(isOn: $pref.postRowShowUserDetails.animation()) {
-          Text("Show User Details")
+          Label("Show User Details", systemImage: "info.circle")
         }
         if pref.postRowShowUserDetails {
           Toggle(isOn: $pref.postRowShowUserRegDate.animation()) {
-            Text("Show User Register Date")
+            Label("Show User Register Date", systemImage: "calendar")
           }
         }
       }
 
-      Section {
-        Toggle(isOn: $pref.usePaginatedDetails) {
-          Label("Paginated Reading", systemImage: "square.stack")
-        }
-      }
     }.tint(.accentColor)
       .navigationTitleInline(string: "")
   }

--- a/app/Shared/Views/UserSignatureView.swift
+++ b/app/Shared/Views/UserSignatureView.swift
@@ -18,7 +18,7 @@ struct UserSignatureView: View {
       Image(systemName: "signature")
         .foregroundColor(.accentColor)
         .imageScale(.small)
-      PostContentView(content: content, defaultFont: font, defaultColor: color)
+      PostContentView(content: content, fontSize: .small, defaultColor: color)
     }
   }
 }


### PR DESCRIPTION
Although the overall font size can be tweaked in control centre, we still introduce this because

- some users may have their own preference for the relative font size (content vs UI) in the app
- some users may find a builtin option more intuitive