### PR TITLE
feat: support full functionality (navigation & sheets) in notification sheet 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ swiftformat:
 	@if [ -z "${SWIFTFORMAT}" ]; then \
 		echo "warning: swiftformat not installed, skip" ;\
 	else \
-		${SWIFTFORMAT} --indent 2 --swiftversion 5.9 --exclude "app/Shared/Protos/*" --exclude "app/Project.swift" . ;\
+		${SWIFTFORMAT} --indent 2 --swiftversion 5.9 --exclude "app/Shared/Protos/*" --exclude "app/Derived/**/*" --exclude "app/Project.swift" . ;\
 	fi
 
 tuist:

--- a/app/Shared/ContentView.swift
+++ b/app/Shared/ContentView.swift
@@ -70,26 +70,25 @@ struct ContentView: View {
 
   var body: some View {
     testBody ?? realBody.eraseToAnyView()
-    #if os(iOS)
-      .safariView(item: $openURL.inAppURL) { url in SafariView(url: url).preferredControlAccentColor(Color("AccentColor")) }
-    #endif
       .onOpenURL { _ = schemes.onNavigateToURL($0) }
-      .fullScreenCover(isPresented: $authStorage.isSigning) { LoginView() }
       .onAppear { if !authStorage.signedIn { authStorage.isSigning = true } }
+      .modifier(MainToastModifier())
+      .preferredColorScheme(prefs.colorScheme.scheme)
+      // Sheets
+      .safariView(item: $openURL.inAppURL) { url in SafariView(url: url).preferredControlAccentColor(Color("AccentColor")) } // this is global-wide, no need to attribute again in sheets
+      .fullScreenCover(isPresented: $authStorage.isSigning) { LoginView() }
       .sheet(isPresented: $activity.activityItems.isNotNil(), content: {
         AppActivityView(activityItems: activity.activityItems ?? [])
       })
-      .modifier(MainToastModifier())
       .sheet(isPresented: $notis.showingSheet) { NotificationListNavigationView() }
       .modifier(GlobalSheetsModifier())
-      .fullScreenCover(isPresented: $viewingImage.showing) { NewImageViewer() }
+      // Global states
       .environmentObject(viewingImage)
       .environmentObject(activity)
       .environmentObject(postReply)
       .environmentObject(shortMessagePost)
       .environmentObject(currentUser)
       .environmentObject(textSelection)
-      .preferredColorScheme(prefs.colorScheme.scheme)
   }
 }
 
@@ -101,12 +100,14 @@ struct GlobalSheetsModifier: ViewModifier {
   @EnvironmentObject var postReply: PostReplyModel
   @EnvironmentObject var shortMessagePost: ShortMessagePostModel
   @EnvironmentObject var textSelection: TextSelectionModel
+  @EnvironmentObject var viewingImage: ViewingImageModel
 
   func body(content: Content) -> some View {
     content
       .sheet(isPresented: $postReply.showEditor) { PostEditorView() }
       .sheet(isPresented: $shortMessagePost.showEditor) { ShortMessageEditorView() }
       .sheet(isPresented: $textSelection.text.isNotNil()) { TextSelectionView().presentationDetents([.medium, .large]) }
+      .fullScreenCover(isPresented: $viewingImage.showing) { NewImageViewer() }
   }
 }
 

--- a/app/Shared/ContentView.swift
+++ b/app/Shared/ContentView.swift
@@ -81,9 +81,7 @@ struct ContentView: View {
       })
       .modifier(MainToastModifier())
       .sheet(isPresented: $notis.showingSheet) { NotificationListNavigationView() }
-      .sheet(isPresented: $postReply.showEditor) { PostEditorView().environmentObject(postReply) }
-      .sheet(isPresented: $shortMessagePost.showEditor) { ShortMessageEditorView().environmentObject(shortMessagePost) }
-      .sheet(isPresented: $textSelection.text.isNotNil()) { TextSelectionView().environmentObject(textSelection).presentationDetents([.medium, .large]) }
+      .modifier(GlobalSheetsModifier())
       .fullScreenCover(isPresented: $viewingImage.showing) { NewImageViewer() }
       .environmentObject(viewingImage)
       .environmentObject(activity)
@@ -92,6 +90,23 @@ struct ContentView: View {
       .environmentObject(currentUser)
       .environmentObject(textSelection)
       .preferredColorScheme(prefs.colorScheme.scheme)
+  }
+}
+
+/// Enable global sheets, including post reply, short message, text selection.
+///
+/// This should be applied to each different navigation stack. For example, the root one
+/// and the one in notification sheet.
+struct GlobalSheetsModifier: ViewModifier {
+  @EnvironmentObject var postReply: PostReplyModel
+  @EnvironmentObject var shortMessagePost: ShortMessagePostModel
+  @EnvironmentObject var textSelection: TextSelectionModel
+
+  func body(content: Content) -> some View {
+    content
+      .sheet(isPresented: $postReply.showEditor) { PostEditorView() }
+      .sheet(isPresented: $shortMessagePost.showEditor) { ShortMessageEditorView() }
+      .sheet(isPresented: $textSelection.text.isNotNil()) { TextSelectionView().presentationDetents([.medium, .large]) }
   }
 }
 

--- a/app/Shared/Views/AboutView.swift
+++ b/app/Shared/Views/AboutView.swift
@@ -14,6 +14,15 @@ struct AboutView: View {
   }
 }
 
+struct AboutNavigationView: View {
+  var body: some View {
+    NavigationStack {
+      AboutView()
+    }
+    .modifier(GlobalSheetsModifier())
+  }
+}
+
 struct AboutView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {

--- a/app/Shared/Views/AttachmentsView.swift
+++ b/app/Shared/Views/AttachmentsView.swift
@@ -14,7 +14,7 @@ struct AttachmentsView: View {
   @EnvironmentObject<ViewingImageModel>.Optional var image
   @ObservedObject var model: AttachmentsModel
 
-  @Environment(\.presentationMode) var presentation
+  @Binding var isPresented: Bool
 
   func image(for attachment: Attachment) -> String {
     switch attachment.type {
@@ -45,7 +45,7 @@ struct AttachmentsView: View {
     guard let url else { return }
 
     if attachment.type == "img" {
-      presentation.dismiss()
+      isPresented = false // dismiss sheet first, otherwise the background will be black
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { // workaround image viewer background
         image?.show(url: url)
       }

--- a/app/Shared/Views/NotificationListView.swift
+++ b/app/Shared/Views/NotificationListView.swift
@@ -74,8 +74,9 @@ struct NotificationListView: View {
 
 struct NotificationListNavigationView: View {
   var body: some View {
-    NavigationView {
+    NavigationStack {
       NotificationListView()
     }
+    .modifier(GlobalSheetsModifier())
   }
 }

--- a/app/Shared/Views/PostRowView.swift
+++ b/app/Shared/Views/PostRowView.swift
@@ -202,7 +202,7 @@ struct PostRowView: View {
     #if os(iOS)
     .listRowBackground(action?.scrollToPid == post.id.pid ? Color.tertiarySystemBackground : nil)
     #endif
-    .sheet(isPresented: $showAttachments) { NavigationView { AttachmentsView(model: attachments) }.presentationDetents([.medium, .large]) }
+    .sheet(isPresented: $showAttachments) { NavigationView { AttachmentsView(model: attachments, isPresented: $showAttachments) }.presentationDetents([.medium, .large]) }
     .environmentObject(attachments)
 
     if let model = postReply, !mock {

--- a/app/Shared/Views/UserMenuView.swift
+++ b/app/Shared/Views/UserMenuView.swift
@@ -137,7 +137,7 @@ struct UserMenuView: View {
       .onAppear { notification.showing = true }
       .onDisappear { notification.showing = false }
       .sheet(isPresented: $showPreferencesModal) { PreferencesView() }
-      .sheet(isPresented: $showAboutViewAsModal) { NavigationStack { AboutView() } }
+      .sheet(isPresented: $showAboutViewAsModal) { AboutNavigationView() }
   }
 
   func reSignIn() {


### PR DESCRIPTION
The key point is that other sheets also need to be attached to the dedicated navigation stack in notification sheet. Extract a modifier to reuse code.