### PR TITLE
feat(ui): minor tweaks on preference page

### DIFF
--- a/app/Shared/MNGAApp.swift
+++ b/app/Shared/MNGAApp.swift
@@ -36,7 +36,7 @@ struct MNGAApp: App {
   func setupColor() {
     #if os(iOS)
       guard let window = UIApplication.myKeyWindow else { return }
-      window.tintColor = prefs.themeColor.color?.toUIColor()
+      window.tintColor = prefs.themeColor.color.toUIColor()
     #endif
   }
 }

--- a/app/Shared/Storage/PreferencesStorage.swift
+++ b/app/Shared/Storage/PreferencesStorage.swift
@@ -17,7 +17,6 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("showAvatar") var showAvatar = true
   @AppStorage("usePaginatedDetails") var usePaginatedDetails = false
   @AppStorage("useInAppSafari") var useInAppSafari = true
-  @AppStorage("imageViewerEnableZoom") var imageViewerEnableZoom = true
   @AppStorage("defaultTopicListOrder") var defaultTopicListOrder = TopicListRequest.Order.lastPost
   @AppStorage("themeColor") var themeColor = ThemeColor.mnga
   @AppStorage("colorScheme") var colorScheme = ColorSchemeMode.auto
@@ -40,7 +39,7 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("postRowShowAuthorIndicator") var postRowShowAuthorIndicator = true
   @AppStorage("postRowLargerFont") var postRowLargerFont = false
 
-  @AppStorage("autoOpenInBrowserWhenBanned") var autoOpenInBrowserWhenBanned = true
+  @AppStorage("autoOpenInBrowserWhenBannedNew") var autoOpenInBrowserWhenBanned = false
 
   init() {
     syncRequestOptionWithLogic()

--- a/app/Shared/Utilities/Appearance.swift
+++ b/app/Shared/Utilities/Appearance.swift
@@ -38,9 +38,10 @@ enum ThemeColor: Int, CaseIterable {
 }
 
 extension ThemeColor {
-  var color: Color? {
+  var color: Color {
     switch self {
-    case .mnga: nil
+    // Note: Color("AccentColor") is always MNGA color, while `.accentColor` is the user's theme color.
+    case .mnga: Color("AccentColor")
     case .blue: .systemBlue
     case .gray: .systemGray
     case .green: .systemGreen

--- a/app/Shared/Views/HotTopicListView.swift
+++ b/app/Shared/Views/HotTopicListView.swift
@@ -86,6 +86,7 @@ struct HotTopicListView: View {
     HotTopicListInnerView.build(forum: forum, range: range)
       .id(range)
       .navigationTitle("Hot Topics")
+      .navigationSubtitle(forum.name)
       .toolbar { ToolbarItem(placement: .mayNavigationBarTrailing) { rangeMenu } }
   }
 }

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -63,7 +63,8 @@ private struct PostRowAppearanceView: View {
         }
       }
 
-    }.tint(.accentColor)
+    }.pickerStyle(.menu)
+      .tint(.accentColor)
       .navigationTitleInline(string: "")
   }
 }
@@ -78,7 +79,8 @@ private struct TopicListAppearanceView: View {
           Label(order.description, systemImage: order.icon).tag(order)
         }
       }
-    }.tint(.accentColor)
+    }.pickerStyle(.menu)
+      .tint(.accentColor)
       .navigationTitleInline(string: "")
   }
 }
@@ -95,10 +97,9 @@ struct PreferencesInnerView: View {
     }
     Picker(selection: $pref.themeColor, label: Label("Theme Color", systemImage: "circle")) {
       ForEach(ThemeColor.allCases, id: \.self) { color in
-        Label(color.description) {
-//          Image(systemName: "circle.fill")
-//            .foregroundColor(color.color ?? Color("AccentColor"))
-        }.tag(color)
+        Label(color.description, systemImage: "circle.fill")
+          .tint(color.color)
+          .tag(color)
       }
     }
     Picker(selection: $pref.useInsetGroupedModern, label: Label("List Style", systemImage: "list.bullet.rectangle.portrait")) {
@@ -152,11 +153,7 @@ struct PreferencesInnerView: View {
   }
 
   @ViewBuilder
-  var advanced: some View {
-    Toggle(isOn: $pref.imageViewerEnableZoom) {
-      Label("Enable Zoom for Image Viewer", systemImage: "arrow.up.left.and.arrow.down.right")
-    }
-  }
+  var advanced: some View {}
 
   @ViewBuilder
   var special: some View {
@@ -179,9 +176,9 @@ struct PreferencesInnerView: View {
         Form { connection }
           .tabItem { Label("Connection", systemImage: "network") }
           .tag("connection")
-        Form { advanced }
-          .tabItem { Label("Advanced", systemImage: "gearshape.2") }
-          .tag("advanced")
+        // Form { advanced }
+        //   .tabItem { Label("Advanced", systemImage: "gearshape.2") }
+        //   .tag("advanced")
       }.tint(.accentColor)
         .pickerStyle(InlinePickerStyle())
         .padding(20)
@@ -190,10 +187,6 @@ struct PreferencesInnerView: View {
   #else
     var body: some View {
       Form {
-        Section(header: Text("Special"), footer: Text("NGA Workaround")) {
-          special
-        }
-
         Section(header: Text("Appearance")) {
           appearance
         }
@@ -206,13 +199,22 @@ struct PreferencesInnerView: View {
           connection
         }
 
-        Section(header: Text("Advanced"), footer: Text("Options here are experimental or unstable.")) {
-          NavigationLink(destination: CacheView()) {
-            Label("Cache", systemImage: "internaldrive")
-          }
-          advanced
+        // There's currently no advanced options.
+        //
+        // Section(header: Text("Advanced"), footer: Text("Options here are experimental or unstable.")) {
+        //   NavigationLink(destination: CacheView()) {
+        //     Label("Cache", systemImage: "internaldrive")
+        //   }
+        //   advanced
+        // }
+
+        Section(header: Text("Special"), footer: Text("NGA Workaround")) {
+          special
         }
       }
+      // Set `pickerStyle` explicitly to fix tint color.
+      // https://stackoverflow.com/questions/74157251/why-doesnt-pickers-tint-color-update
+      .pickerStyle(.menu)
       .tint(.accentColor)
       .mayInsetGroupedListStyle()
       .navigationTitle("Preferences")

--- a/app/Shared/Views/RecommendedTopicListView.swift
+++ b/app/Shared/Views/RecommendedTopicListView.swift
@@ -52,5 +52,6 @@ struct RecommendedTopicListView: View {
         .mayGroupedListStyle()
       }
     }.navigationTitle("Recommended Topics")
+      .navigationSubtitle(forum.name)
   }
 }

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -214,13 +214,13 @@ struct TopicDetailsView: View {
         }
       }
 
-      #if os(iOS)
-        ShareLinksView(navigationID: navID) {
-          Button(action: shareAsImage) {
-            Label("Screenshot (Beta)", systemImage: "text.below.photo")
-          }
-        }
-      #endif
+      // #if os(iOS)
+      //   ShareLinksView(navigationID: navID) {
+      //     Button(action: shareAsImage) {
+      //       Label("Screenshot (Beta)", systemImage: "text.below.photo")
+      //     }
+      //   }
+      // #endif
 
       Section {
         if let atForum {

--- a/logic/service/src/constants.rs
+++ b/logic/service/src/constants.rs
@@ -9,7 +9,7 @@ pub const MNGA_ICON_PATH: &str = "https://github.com/BugenZhao/MNGA/blob/5c0e519
 
 pub const SUCCESS_MSGS: &[&str] = &["完毕", "没找到", "没有符合条件的结果", "今天已经签到"];
 
-pub const APPLE_UA: &str = "NGA_skull/7.3.1(iPhone13,2;iOS 15.5)";
+pub const APPLE_UA: &str = "NGA_skull/7.3.1(iPhone17,1;iOS 26.0)";
 pub const ANDROID_UA: &str = "Nga_Official/80024(Android12)";
 pub const DESKTOP_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36";
 pub const WINDOWS_PHONE_UA: &str = "NGA_WP_JW/(;WINDOWS)";

--- a/logic/service/src/fetch.rs
+++ b/logic/service/src/fetch.rs
@@ -134,10 +134,12 @@ where
         get_global_client()
     };
 
+    let ua = &*device_ua(api);
     let builder = client
         .request(method, url)
         .query(&query)
-        .header("X-User-Agent", &*device_ua(api));
+        .header("User-Agent", ua)
+        .header("X-User-Agent", ua);
     let builder = add_form(builder);
 
     let request = builder.build()?;


### PR DESCRIPTION
- Show the preview of color in color scheme picker
- Correctly tint the color of picker
- Remove unused "scaling" option for image viewer
- Move the special section to the bottom, default "auto open in browser" to false
- [piggyback] add subtitle to hot topics & recommended topics page
- [piggyback] bump ua