### PR TITLE
feat(ui): better refreshing

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -232,6 +232,7 @@
 "Add Tag" = "添加标签";
 "Larger Font" = "更大字体";
 "Unknown" = "未知";
+"Auto Refreshed" = "已自动刷新";
 
 "Error Response" = "错误响应";
 "Missing Field" = "缺少字段";

--- a/app/Shared/Models/ToastModel.swift
+++ b/app/Shared/Models/ToastModel.swift
@@ -23,6 +23,7 @@ class ToastModel: ObservableObject {
     case userSwitch(String)
     case clockIn(String)
     case openURL(URL)
+    case autoRefreshed
   }
 
   @Published var message: Message? = nil
@@ -51,7 +52,7 @@ class ToastModel: ObservableObject {
     switch message {
     case .success, .error:
       ToastModel.banner.message = message
-    case .notification, .userSwitch, .clockIn:
+    case .notification, .userSwitch, .clockIn, .autoRefreshed:
       ToastModel.hud.message = message
     case .openURL:
       ToastModel.alert.message = message
@@ -77,6 +78,8 @@ extension ToastModel.Message {
       AlertToast(displayMode: displayMode, type: .systemImage("lanyardcard", .accentColor), title: "Clocked in Successfully".localized, subTitle: msg)
     case let .openURL(url):
       AlertToast(displayMode: displayMode, type: .complete(.accentColor), title: "Navigated to Link".localized, subTitle: url.absoluteString)
+    case .autoRefreshed:
+      AlertToast(displayMode: displayMode, type: .systemImage("checkmark.arrow.trianglehead.clockwise", .accentColor), title: "Auto Refreshed".localized, subTitle: nil)
     }
   }
 }

--- a/app/Shared/Utilities/Logger.swift
+++ b/app/Shared/Utilities/Logger.swift
@@ -10,6 +10,10 @@ import Logging
 
 let logger: Logger = {
   var logger = Logger(label: "App")
-  logger.logLevel = .info
+  #if DEBUG
+    logger.logLevel = .debug
+  #else
+    logger.logLevel = .info
+  #endif
   return logger
 }()

--- a/app/Shared/Views/HotTopicListView.swift
+++ b/app/Shared/Views/HotTopicListView.swift
@@ -37,20 +37,23 @@ struct HotTopicListInnerView: View {
   }
 
   var body: some View {
-    if dataSource.notLoaded {
-      ProgressView()
-        .onAppear { dataSource.initialLoad() }
-    } else {
-      List {
-        Section(header: Text(range.description)) {
-          ForEach($dataSource.items, id: \.id) { topic in
-            NavigationLink(destination: TopicDetailsView.build(topicBinding: topic)) {
-              TopicRowView(topic: topic.w)
+    Group {
+      if dataSource.notLoaded {
+        ProgressView()
+          .onAppear { dataSource.initialLoad() }
+      } else {
+        List {
+          Section(header: Text(range.description)) {
+            ForEach($dataSource.items, id: \.id) { topic in
+              NavigationLink(destination: TopicDetailsView.build(topicBinding: topic)) {
+                TopicRowView(topic: topic.w)
+              }
             }
           }
-        }
-      }.mayGroupedListStyle()
+        }.mayGroupedListStyle()
+      }
     }
+    .refreshable(dataSource: dataSource)
   }
 }
 

--- a/app/Shared/Views/RecommendedTopicListView.swift
+++ b/app/Shared/Views/RecommendedTopicListView.swift
@@ -53,5 +53,6 @@ struct RecommendedTopicListView: View {
       }
     }.navigationTitle("Recommended Topics")
       .navigationSubtitle(forum.name)
+      .refreshable(dataSource: dataSource)
   }
 }

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -231,9 +231,11 @@ struct TopicDetailsView: View {
         #if os(iOS)
           favoriteButton
         #endif
-        Button(action: { dataSource.refresh() }) {
-          Label("Refresh", systemImage: "arrow.clockwise")
-        }
+        #if os(macOS)
+          Button(action: { dataSource.refresh() }) {
+            Label("Refresh", systemImage: "arrow.clockwise")
+          }
+        #endif
       }
     } label: {
       Label("More", systemImage: "ellipsis.circle")
@@ -506,6 +508,7 @@ struct TopicDetailsView: View {
       .if(subtitle != nil, content: { $0.navigationSubtitle(subtitle!) })
       .navigationBarTitleDisplayMode(.inline)
       .toolbar { toolbar }
+      .refreshable(dataSource: dataSource)
       .toolbarRole(.editor) // make title left aligned
       .onChange(of: postReply.sent) { reloadPageAfter(sent: $1) }
       .onChange(of: dataSource.latestResponse) { onNewResponse(response: $1) }

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -474,11 +474,11 @@ struct TopicDetailsView: View {
       }.onReceive(action.$scrollToFloor) { floor in
         guard let floor else { return }
         let item = dataSource.items.first { $0.floor == UInt32(floor) }
-        proxy.scrollTo(item, anchor: .top)
+        withAnimation { proxy.scrollTo(item, anchor: .top) }
       }.onReceive(action.$scrollToPid) { pid in
         guard let pid else { return }
         let item = dataSource.items.first { $0.id.pid == pid }
-        proxy.scrollTo(item, anchor: .top)
+        withAnimation { proxy.scrollTo(item, anchor: .top) }
       }
     }.mayGroupedListStyle()
       // Action Navigation

--- a/app/Shared/Views/TopicListView.swift
+++ b/app/Shared/Views/TopicListView.swift
@@ -242,6 +242,7 @@ struct TopicListView: View {
           }
       } else {
         List {
+          EmptyView().id("top-placeholder") // for auto refresh
           ForEach(itemBindings, id: \.id) { topic in
             CrossStackNavigationLinkHack(id: topic.w.id, destination: {
               TopicDetailsView.build(topicBinding: topic)

--- a/app/Shared/Views/UserProfileView.swift
+++ b/app/Shared/Views/UserProfileView.swift
@@ -182,6 +182,9 @@ struct UserProfileView: View {
     .withTopicDetailsAction() // for signature only
     .mayGroupedListStyle()
     .navigationTitleInline(string: title)
+    // This will trigger redraw for user view, which is not good.
+    // .if(shouldShowList && tab == .topics) { $0.refreshable(dataSource: topicDataSource) }
+    // .if(shouldShowList && tab == .posts) { $0.refreshable(dataSource: postDataSource) }
   }
 
   func newShortMessage() {


### PR DESCRIPTION
- When the app is running in background for 1 hour, auto refresh topic list when entering foreground again (#47, close #32)
- Make more topic list to be refreshable
- Remove refresh button in topic details, use pull-to-refresh instead.