### PR TITLE
fix: use github pages instead of usercontent for mnga meta

### DIFF
--- a/app/Shared/Utilities/URLs.swift
+++ b/app/Shared/Utilities/URLs.swift
@@ -9,9 +9,6 @@ import Foundation
 
 enum URLs {
   static let attachmentBase = URL(string: "https://img.nga.178.com/attachments/")!
-  static let testFlight = URL(string: "https://testflight.apple.com/join/qFDuytLt")!
-  static let gitHub = URL(string: "https://github.com/BugenZhao/MNGA")!
-  static let mailTo = URL(string: "mailto:mnga.feedback@bugenzhao.com")!
 
   static let defaultHost = "nga.178.com"
   static let hosts = [defaultHost, "bbs.nga.cn", "ngabbs.com"]

--- a/logic/service/src/constants.rs
+++ b/logic/service/src/constants.rs
@@ -1,8 +1,7 @@
 #![allow(unused)]
 
 pub const DEFAULT_BASE_URL: &str = "https://nga.178.com";
-pub const DEFAULT_MOCK_BASE_URL: &str =
-    "https://raw.githubusercontent.com/BugenZhao/MNGA/gh-pages/api/";
+pub const DEFAULT_MOCK_BASE_URL: &str = "https://mnga-pages.bugenzhao.com/api/";
 pub const DEFAULT_PROXY_BASE_URL: &str = "https://nga.bugenzhao.com";
 pub const FORUM_ICON_PATH: &str = "http://img4.ngacn.cc/ngabbs/nga_classic/f/app/";
 pub const MNGA_ICON_PATH: &str = "https://github.com/BugenZhao/MNGA/blob/5c0e519f9064ab1d7dbfb8e14aa2a96fc7058419/assets/MNGA-round-liquid-glass-compressed.png";


### PR DESCRIPTION
It doesn't seem accessible in China Mainland.

Signed-off-by: Bugen Zhao <i@bugenzhao.com>