### PR TITLE
fix: disordering after favorite forums `onMove`

### DIFF
--- a/app/Shared/Views/ForumListView.swift
+++ b/app/Shared/Views/ForumListView.swift
@@ -54,6 +54,8 @@ struct ForumListView: View {
         }.onMove { from, to in
           favorites.favoriteForums.move(fromOffsets: from, toOffset: to)
         }
+        // Hack for disordering after `onMove`
+        .id(favorites.favoriteForums.hashValue)
       }
     }
   }


### PR DESCRIPTION
It doesn't seem to be the issue of `AppStorage` or `id`...