### PR TITLE
fix: split `connect_timeout` and `read_timeout`

### DIFF
--- a/logic/service/src/fetch.rs
+++ b/logic/service/src/fetch.rs
@@ -58,7 +58,8 @@ fn build_client() -> Client {
     log::info!("build reqwest client");
     Client::builder()
         .https_only(true)
-        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5))
+        .read_timeout(Duration::from_secs(20))
         .gzip(true)
         .build()
         .expect("failed to build reqwest client")


### PR DESCRIPTION
Instead of using a end-to-end timeout of 10s for reqwest, we may use a shorter connection timeout and longer read timeout for better UX.