### PR TITLE
fix(ui): resume progress icons with Plus feature

### DIFF
--- a/app/Shared/Utilities/WhatsNew.swift
+++ b/app/Shared/Utilities/WhatsNew.swift
@@ -81,7 +81,7 @@ struct MNGAWhatsNew: WhatsNewCollectionProvider {
       title: whatsNewTitle(version: "2.1"),
       features: [
         .init(
-          image: .init(systemName: "arrowshape.turn.up.left"),
+          image: .init(systemName: "clock.arrow.circlepath"),
           title: "保存阅读进度",
           subtitle: "自动记录你读过的楼层，久未返回会贴心刷新，一打开就续上最新进度。"
         ),

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -201,7 +201,7 @@ struct PreferencesInnerView: View {
       Text("Last Read Floor").tag(TopicResumeFrom.last)
       Text("Highest Read Floor").tag(TopicResumeFrom.highest)
     } label: {
-      Label("Resume Reading Progress", systemImage: "arrowshape.turn.up.left")
+      Label("Resume Reading Progress", systemImage: "clock.arrow.circlepath")
     }.disableWithPlusCheck(.resumeProgress)
 
     Toggle(isOn: $pref.useInAppSafari) {


### PR DESCRIPTION
## Summary
- update the reading progress icon in the 2.1 WhatsNew entry to use `clock.arrow.circlepath`
- match the Preferences reading progress picker icon to the same Plus feature symbol

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a38634cac8333ac0083ded0dbb1a9