### PR TITLE
feat(ui): support parsing and combining `[album]`

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -322,6 +322,7 @@
 "Search Bar Position" = "搜索栏位置";
 "Top" = "顶部";
 "Bottom" = "底部";
+"Album" = "相册";
 
 "All Plus Features" = "Plus 功能一览";
 "Comment on posts in all topics." = "在话题中对帖子进行贴条。";

--- a/app/Shared/Utilities/ContentCombiner.swift
+++ b/app/Shared/Utilities/ContentCombiner.swift
@@ -365,6 +365,8 @@ class ContentCombiner {
       visit(divider: tagged)
     case "img":
       visit(image: tagged)
+    case "album":
+      visit(album: tagged)
     case "noimg":
       visit(noimg: tagged)
     case "quote":
@@ -429,6 +431,20 @@ class ContentCombiner {
     let onlyThumbs = inQuote && replyTo != nil
     let image = ContentImageView(url: url, onlyThumbs: onlyThumbs)
     append(image)
+  }
+
+  private func visit(album: Span.Tagged) {
+    let urls = album.spans.filter { if case .plain = $0.value { true } else { false } }
+    let name = "\(album.attributes.first ?? "Album".localized) (\(urls.count))"
+
+    visit(divider: .with {
+      $0.spans = [.plainText(name)]
+    })
+    for url in urls {
+      visit(image: .with {
+        $0.spans = [url]
+      })
+    }
   }
 
   private func visit(noimg: Span.Tagged) {


### PR DESCRIPTION
Fix #289

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c5ea0c37-9de6-4cc8-b627-ed2af4a0fcb8" />
