### PR TITLE
fix: use full width for items in content combiner

### DIFF
--- a/app/Shared/Utilities/ContentCombiner.swift
+++ b/app/Shared/Utilities/ContentCombiner.swift
@@ -266,6 +266,7 @@ class ContentCombiner {
         ForEach(results.indices, id: \.self) { index in
           results[index]
             .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
 
       switch tableContext {


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>