### PR TITLE
fix: fix navigation on ipad

### DIFF
--- a/app/Shared/Views/TopicListView.swift
+++ b/app/Shared/Views/TopicListView.swift
@@ -49,7 +49,6 @@ struct TopicListView: View {
   @StateObject var prefs = PreferencesStorage.shared
 
   @State var currentShowingSubforum: Forum? = nil
-  @State var showingSubforum: Bool = false
   @State var showingSubforumsModal = false
   @State var order: TopicListRequest.Order? = nil
   @State var triggerRefresh = false
@@ -232,7 +231,6 @@ struct TopicListView: View {
             onNavigateToForum: { subforum in
               showingSubforumsModal = false
               currentShowingSubforum = subforum
-              showingSubforum = true
             }
           )
         } else {
@@ -360,8 +358,7 @@ struct TopicListView: View {
     .scrollAwareTitle { principal }
     .sheet(isPresented: $showingSubforumsModal) { subforumsModal }
     .onChange(of: postReply?.sent) { dataSource.reload(page: 1, evenIfNotLoaded: false) }
-    // .navigationDestination(item: $currentShowingSubforum) { TopicListView.build(forum: $0) }
-    .navigationDestination(isPresented: $showingSubforum) { if let f = currentShowingSubforum { TopicListView.build(forum: f) } }
+    .navigationDestination(item: $currentShowingSubforum) { TopicListView.build(forum: $0) }
     .toolbar { toolbar }
     .onChange(of: prefs.defaultTopicListOrder) { if $1 != order { order = $1 } }
     .onAppear { if order == nil { order = prefs.defaultTopicListOrder } }


### PR DESCRIPTION
Without `NavigationStack` in content and details view, some navigation may get stuck (like subforum) and others may get the back button missing (like hot/recommend topics). Not sure about the reason but this reverts some changes in #318 and fixed those all issues.