### PR TITLE
chore: tweak logic build options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Remember to update localization file at `app/Shared/Localization/zh-Hans.lproj/L
 - `make logic-ios` - Build iOS framework
 - `make swift-pb` - Generate Swift protobuf code
 - `make logic-sim` - Build simulator-only version (faster for development)
-- `make logic-deploy` - Build production version
+- `make logic-deploy` - Build release version
 
 ## Important Notes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,5 @@ members = [
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 
-[profile.production]
-inherits = "release"
-opt-level = "s"   # Optimize for size.
-lto = true        # Enable link time optimization
+[profile.release]
+lto = true

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ endif
 
 .PHONY: logic
 
-ios: logic-ios-production
-macos: logic-macos-production
+ios: logic-ios-release
+macos: logic-macos-release
 
 logic-ios-%:
 	make logic-ios MODE=$*
@@ -45,7 +45,7 @@ logic-ios:
 logic-sim:
 	make logic ALL_TARGETS="${IOS_SIM_TARGET}" MODE=debug
 logic-deploy:
-	make logic ALL_TARGETS="${IOS_TARGET}" MODE=production
+	make logic ALL_TARGETS="${IOS_TARGET}" MODE=release
 
 logic-macos-%:
 	make logic-macos MODE=$*
@@ -89,11 +89,6 @@ create-framework:
 	@CMD="xcodebuild -create-xcframework" ;\
 	for target in ${ALL_TARGETS}; do \
 		logic_lib="${TARGET_DIR}/$${target}/${MODE}/liblogic.a" ;\
-		if [[ ${MODE} != "debug" ]]; then \
-			strip_cmd="strip $${logic_lib}" ;\
-			echo ">>> $${strip_cmd}" ;\
-			$${strip_cmd} >/dev/null 2>&1 || true ;\
-		fi ;\
 		CMD="$${CMD} -library $${logic_lib}" ;\
 	done ;\
 	CMD="$${CMD} -headers ${OUT_INCLUDE}/* -output ${OUT_FRAMEWORK}" ;\


### PR DESCRIPTION
- Use release profile
- Do not optimize for size
- Do not strip `.a` ourselves but defer to Xcode archiver