### PR TITLE
feat(ui): locate-floor jump in reply chain

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -114,6 +114,7 @@
 "User Profile" = "用户档案";
 "Author Only" = "只看作者";
 "This Author Only" = "只看该作者";
+"Locate This Floor" = "定位此层";
 "Topic (Cached)" = "话题（缓存）";
 "View Cached Topic" = "查看本地缓存";
 "Cache Loaded" = "已加载本地缓存";

--- a/app/Shared/Views/PostReplyChainView.swift
+++ b/app/Shared/Views/PostReplyChainView.swift
@@ -14,13 +14,25 @@ struct PostReplyChainView: View {
   @ObservedObject var resolver: QuotedPostResolver
   @StateObject private var action = TopicDetailsActionModel()
   @StateObject var prefs = PreferencesStorage.shared
+  @Environment(\.dismiss) private var dismiss
 
   let chain: [PostId]
   let topic: Topic
+  let locateFloorInTopic: ((Post) -> Void)?
 
   @ViewBuilder
   func buildRow(post: Post) -> some View {
-    PostRowView.build(post: post, screenshotTopic: topic, vote: votes.binding(for: post))
+    PostRowView.build(
+      post: post,
+      screenshotTopic: topic,
+      vote: votes.binding(for: post),
+      locateFloor: locateFloorInTopic == nil ? nil : { _ in
+        dismiss()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+          locateFloorInTopic?(post)
+        }
+      },
+    )
   }
 
   var body: some View {

--- a/app/Shared/Views/PostRowView.swift
+++ b/app/Shared/Views/PostRowView.swift
@@ -67,6 +67,7 @@ struct PostRowView: View {
   let post: Post
   let isAuthor: Bool
   let screenshotTopic: Topic?
+  let locateFloor: ((Post) -> Void)?
 
   @Binding var vote: VotesModel.Vote
 
@@ -91,12 +92,14 @@ struct PostRowView: View {
     isAuthor: Bool = false,
     screenshotTopic: Topic? = nil,
     vote: Binding<VotesModel.Vote>,
+    locateFloor: ((Post) -> Void)? = nil,
   ) -> Self {
     let attachments = AttachmentsModel(post.attachments)
     return .init(
       post: post,
       isAuthor: isAuthor,
       screenshotTopic: screenshotTopic,
+      locateFloor: locateFloor,
       vote: vote,
       attachments: attachments,
     )
@@ -252,6 +255,11 @@ struct PostRowView: View {
           Label("This Author Only", systemImage: "person")
         }
       }
+      if let locateFloor {
+        Button(action: { locateFloor(post) }) {
+          Label("Locate This Floor", systemImage: "scope")
+        }
+      }
     }
     ShareLinksView(navigationID: navID, viewScreenshot: { viewScreenshot() })
   }
@@ -318,12 +326,15 @@ struct PostRowView: View {
       }
       .environmentObject(attachments)
       .swipeActions(edge: pref.postRowSwipeActionLeading ? .leading : .trailing) { swipeActions }
-      .onChange(of: shouldHighlight, initial: true) { if $1 {
+      .onChange(of: shouldHighlight, initial: true) { _, shouldHighlight in
+        guard shouldHighlight else { return }
+        action?.scrollToPid = nil
+
         withAnimation { highlight = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
           withAnimation { highlight = false }
         }
-      }}
+      }
       .listRowBackground(highlight ? Color.accentColor.opacity(0.1) : nil) // TODO: why not animated?
   }
 

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -734,7 +734,15 @@ struct TopicDetailsView: View {
     .withTopicDetailsAction(action: action)
     .environmentObject(quotedPosts)
     .navigationDestination(item: $action.showingReplyChain) {
-      PostReplyChainView(votes: votes, resolver: quotedPosts, chain: $0, topic: topic)
+      PostReplyChainView(
+        votes: votes,
+        resolver: quotedPosts,
+        chain: $0,
+        topic: topic,
+        locateFloorInTopic: onlyPost.id == nil ? { post in
+          action.scrollToPid = post.id.pid
+        } : nil,
+      )
     }
     .navigationDestination(item: $action.navigateToAuthorOnly) {
       TopicDetailsView.build(topic: topic, only: $0)


### PR DESCRIPTION
This adds a "Locate This Floor" action in reply-chain post menus and routes it back to Topic Details to scroll to the target post. The action is available only when opened from full topic details (not only-post mode). The scroll highlight is now consumed once per locate action so it does not re-trigger when the row is recycled. Added zh-Hans localization for the new menu label.