### PR TITLE
Add prefixed share titles for shared links

### DIFF
--- a/app/Shared/Views/PostRowView.swift
+++ b/app/Shared/Views/PostRowView.swift
@@ -266,7 +266,11 @@ struct PostRowView: View {
         }
       }
     }
-    ShareLinksView(navigationID: navID, viewScreenshot: { viewScreenshot() })
+    ShareLinksView(
+      navigationID: navID,
+      shareTitle: screenshotTopic?.subject.full,
+      viewScreenshot: { viewScreenshot() },
+    )
   }
 
   @ViewBuilder

--- a/app/Shared/Views/ShareLinksView.swift
+++ b/app/Shared/Views/ShareLinksView.swift
@@ -10,30 +10,56 @@ import SwiftUI
 
 struct ShareLinksView<V: View>: View {
   let navigationID: NavigationIdentifier
+  let shareTitle: String?
   let viewScreenshot: (() -> Void)?
   @ViewBuilder let others: () -> V
 
   init(
     navigationID: NavigationIdentifier,
+    shareTitle: String? = nil,
     viewScreenshot: (() -> Void)? = nil,
     @ViewBuilder others: @escaping () -> V = { EmptyView() },
   ) {
     self.navigationID = navigationID
+    self.shareTitle = shareTitle
     self.viewScreenshot = viewScreenshot
     self.others = others
+  }
+
+  var normalizedShareTitle: String? {
+    guard let shareTitle else { return nil }
+    let normalized = shareTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    return normalized.isEmpty ? nil : normalized
+  }
+
+  func prefixedShareTitle(_ prefix: String) -> String? {
+    guard let title = normalizedShareTitle else { return nil }
+    return "\(prefix)\(title)"
   }
 
   var body: some View {
     Menu {
       if let mngaURL = navigationID.mngaURL {
-        ShareLink(item: mngaURL) {
-          Label("MNGA Link", systemImage: "m.circle")
+        if let title = prefixedShareTitle("MNGA - ") {
+          ShareLink(item: mngaURL, message: Text(title)) {
+            Label("MNGA Link", systemImage: "m.circle")
+          }
+        } else {
+          ShareLink(item: mngaURL) {
+            Label("MNGA Link", systemImage: "m.circle")
+          }
         }
       }
 
       if let webpageURL = navigationID.webpageURL {
-        ShareLink(item: webpageURL) {
-          Label("NGA Link", systemImage: "network")
+        if let title = prefixedShareTitle("NGA - ") {
+          ShareLink(item: webpageURL, message: Text(title)) {
+            Label("NGA Link", systemImage: "network")
+          }
+        } else {
+          ShareLink(item: webpageURL) {
+            Label("NGA Link", systemImage: "network")
+          }
         }
       }
 

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -400,7 +400,7 @@ struct TopicDetailsView: View {
         }
       }
 
-      ShareLinksView(navigationID: topic.navID, viewScreenshot: { viewScreenshot() })
+      ShareLinksView(navigationID: topic.navID, shareTitle: topic.subject.full, viewScreenshot: { viewScreenshot() })
 
       Section {
         favoriteMenu

--- a/app/Shared/Views/TopicListView.swift
+++ b/app/Shared/Views/TopicListView.swift
@@ -199,7 +199,7 @@ struct TopicListView: View {
         }
       }
 
-      ShareLinksView(navigationID: navID)
+      ShareLinksView(navigationID: navID, shareTitle: forum.name)
 
       Section {
         Button(action: { favoriteForums.toggle(forum: forum) }) {

--- a/app/Shared/Views/TopicRowView.swift
+++ b/app/Shared/Views/TopicRowView.swift
@@ -98,7 +98,7 @@ struct TopicRowLinkView: View {
       CrossStackNavigationLinkHack(id: topic.id, destination: { destination }) {
         Label("Goto Topic", systemImage: "arrow.right")
       }
-      ShareLinksView(navigationID: topic.navID)
+      ShareLinksView(navigationID: topic.navID, shareTitle: topic.subject.full)
     } preview: {
       TopicDetailsView.build(topicBinding: $topic, previewMode: true)
     }

--- a/app/Shared/Views/UserProfileView.swift
+++ b/app/Shared/Views/UserProfileView.swift
@@ -164,7 +164,7 @@ struct UserProfileView: View {
 
         if !user.isAnonymous {
           Section {
-            ShareLinksView(navigationID: .userID(user.id))
+            ShareLinksView(navigationID: .userID(user.id), shareTitle: user.name.display)
           }
         }
       } label: {


### PR DESCRIPTION
This updates ShareLinksView to include optional share titles when sharing MNGA and NGA links. The shared message text now prefixes titles with "MNGA - " for app links and "NGA - " for web links. Topic, forum, user, and post sharing entry points now pass contextual titles into ShareLinksView. Validation: make build.