### PR TITLE
fastlane: fix beta build number selection

### DIFF
--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -55,8 +55,21 @@ platform :ios do
       match(type: "appstore")
     end
 
+    testflight_build_number = latest_testflight_build_number.to_i
+    latest_tag_build_number =
+      sh("git tag --list 'builds/iosbeta/*'")
+        .split("\n")
+        .filter_map do |tag|
+          match = tag.match(%r{\Abuilds/iosbeta/(\d+)\z})
+          match[1].to_i if match
+        end
+        .max || 0
+
+    next_build_number = [testflight_build_number, latest_tag_build_number].max + 1
+    UI.message("Next build number: #{next_build_number} (testflight=#{testflight_build_number}, tag=#{latest_tag_build_number})")
+
     increment_build_number(
-      build_number: latest_testflight_build_number + 1,
+      build_number: next_build_number,
       xcodeproj: "MNGA.xcodeproj",
     )
 


### PR DESCRIPTION
This fixes release build-number selection in the iOS beta lane.\n\nInstead of using only latest_testflight_build_number + 1, it now computes the next number from the max of TestFlight and existing git tags under builds/iosbeta/*.\n\nThis prevents collisions like trying to create an already-existing tag and logs both inputs for easier debugging.