### PR TITLE
feat: add topic title copy actions

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -150,6 +150,7 @@
 "%lld new unread notifications" = "%lld 个新的未读通知";
 "Replies Chain" = "回复链";
 "Goto Topic" = "前往话题";
+"Copy Title" = "拷贝标题";
 "Short Message Details" = "短消息详情";
 "Appearance" = "外观";
 "Custom Appearance" = "自定义外观";

--- a/app/Shared/Views/GenericEditorView.swift
+++ b/app/Shared/Views/GenericEditorView.swift
@@ -49,7 +49,7 @@ private struct GenericEditorViewInner<T: TaskProtocol, M: GenericPostModel<T>>: 
   @ViewBuilder
   var previewInner: some View {
     if let subject {
-      TopicSubjectView(topic: .with { $0.subject = subject }, showIndicators: false)
+      TopicSubjectView(topic: .with { $0.subject = subject }, showIndicators: false, selectableContent: true)
     }
 
     VStack(alignment: .leading, spacing: 10) {

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -471,7 +471,7 @@ struct TopicDetailsView: View {
 
   @ViewBuilder
   var headerSectionInner: some View {
-    TopicSubjectView(topic: topic, lineLimit: nil)
+    TopicSubjectView(topic: topic, lineLimit: nil, selectableContent: true)
       .fixedSize(horizontal: false, vertical: true)
 
     if let first, firstFloorExpanded {

--- a/app/Shared/Views/TopicRowView.swift
+++ b/app/Shared/Views/TopicRowView.swift
@@ -90,6 +90,11 @@ struct TopicRowLinkView: View {
     TopicDetailsView.build(topicBinding: $topic)
   }
 
+  var copyableTitle: String? {
+    let title = topic.subjectContentCompat.trimmingCharacters(in: .whitespacesAndNewlines)
+    return title.isEmpty ? nil : title
+  }
+
   var body: some View {
     CrossStackNavigationLinkHack(id: topic.id, destination: { destination }) {
       TopicRowView(topic: topic, useTopicPostDate: useTopicPostDate, dimmedSubject: dimmedSubject, showIndicators: showIndicators)
@@ -97,6 +102,11 @@ struct TopicRowLinkView: View {
     .contextMenu {
       CrossStackNavigationLinkHack(id: topic.id, destination: { destination }) {
         Label("Goto Topic", systemImage: "arrow.right")
+      }
+      if let copyableTitle {
+        Button(action: { copyToPasteboard(string: copyableTitle) }) {
+          Label("Copy Title", systemImage: "doc.on.doc")
+        }
       }
       ShareLinksView(navigationID: topic.navID, shareTitle: topic.subject.full)
     } preview: {

--- a/app/Shared/Views/TopicSubjectView.swift
+++ b/app/Shared/Views/TopicSubjectView.swift
@@ -26,11 +26,13 @@ struct TopicSubjectContentInnerView: View {
   let content: String
   let lineLimit: Int?
   let modifiers: [Subject.FontModifier]
+  let selectable: Bool
 
-  init(content: String, lineLimit: Int? = nil, modifiers: [Subject.FontModifier] = []) {
+  init(content: String, lineLimit: Int? = nil, modifiers: [Subject.FontModifier] = [], selectable: Bool = false) {
     self.content = content
     self.lineLimit = lineLimit
     self.modifiers = modifiers
+    self.selectable = selectable
   }
 
   func applyFontModifiers(_ text: Text, dimmed: Bool) -> Text {
@@ -65,19 +67,19 @@ struct TopicSubjectContentInnerView: View {
   }
 
   var body: some View {
-    Group {
-      if content.isEmpty {
-        Text("Untitled")
-          .font(.headline.weight(.medium).italic())
-          .foregroundColor(.secondary)
-      } else {
-        Text(content)
-          .font(.headline.weight(.medium)) // headline is semibold by default
-          .if(prefs.topicListSubjectMulticolor) { applyFontModifiers($0, dimmed: topicSubjectDimmed) }
-          .foregroundColor(topicSubjectDimmed ? .secondary : .primary) // applicable for subjects without color modifiers
-      }
+    if content.isEmpty {
+      Text("Untitled")
+        .font(.headline.weight(.medium).italic())
+        .foregroundColor(.secondary)
+        .lineLimit(lineLimit)
+    } else {
+      Text(content)
+        .font(.headline.weight(.medium)) // headline is semibold by default
+        .if(prefs.topicListSubjectMulticolor) { applyFontModifiers($0, dimmed: topicSubjectDimmed) }
+        .foregroundColor(topicSubjectDimmed ? .secondary : .primary) // applicable for subjects without color modifiers
+        .if(selectable) { $0.textSelection(.enabled) }
+        .lineLimit(lineLimit)
     }
-    .lineLimit(lineLimit)
   }
 }
 
@@ -85,11 +87,13 @@ struct TopicSubjectView: View {
   let topic: Topic
   let lineLimit: Int?
   let showIndicators: Bool
+  let selectableContent: Bool
 
-  init(topic: Topic, lineLimit: Int? = nil, showIndicators: Bool = false) {
+  init(topic: Topic, lineLimit: Int? = nil, showIndicators: Bool = false, selectableContent: Bool = false) {
     self.topic = topic
     self.lineLimit = lineLimit
     self.showIndicators = showIndicators
+    self.selectableContent = selectableContent
   }
 
   @ViewBuilder
@@ -136,6 +140,7 @@ struct TopicSubjectView: View {
         content: content,
         lineLimit: lineLimit,
         modifiers: topic.subject.fontModifiers,
+        selectable: selectableContent,
       )
     }
   }


### PR DESCRIPTION
## Summary
- add a Copy Title action to topic row context menus using subject body only
- enable native text selection for topic subject body in topic details and editor preview
- add zh-Hans localization for Copy Title

## Testing
- make swiftformat
- make build