### PR TITLE
Add option to hide notification toolbar shortcut

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "Appearance" = "外观";
 "Custom Appearance" = "自定义外观";
 "Theme Color" = "主题色";
+"Hide Notification Shortcut" = "隐藏通知快捷入口";
 "New Short Message" = "发表短消息";
 "Send To" = "发送至";
 "Separate multiple users with space." = "使用空格分隔多个用户。";

--- a/app/Shared/Storage/PreferencesStorage.swift
+++ b/app/Shared/Storage/PreferencesStorage.swift
@@ -25,6 +25,7 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("topicListShowForumShortcut") var topicListShowForumShortcut = true
   @AppStorage("topicListShowSearchInBottomBar") var topicListShowSearchInBottombar = true
   @AppStorage("topicListSubjectMulticolor") var topicListSubjectMulticolor = true
+  @AppStorage("hideNotificationToolbarShortcut") var hideNotificationToolbarShortcut = false
   @AppStorage("themeColorNew") var themeColor = ThemeColor.mnga
   @AppStorage("colorScheme") var colorScheme = ColorSchemeMode.auto
   @AppStorage("useInsetGroupedModern") var useInsetGroupedModern = true

--- a/app/Shared/Views/NotificationListView.swift
+++ b/app/Shared/Views/NotificationListView.swift
@@ -166,7 +166,8 @@ struct NotificationToolbarItem: ToolbarContent {
   @ViewBuilder
   var bodyView: some View {
     // Only show if not from notification list view.
-    if unreadCount > 0 || prefs.debugAlwaysShowNotificationBadge,
+    if !prefs.hideNotificationToolbarShortcut,
+       unreadCount > 0 || prefs.debugAlwaysShowNotificationBadge,
        show == .fromUserMenu || !notis.showingFromUserMenu,
        !inNotificationSheet
     {

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -228,6 +228,10 @@ struct PreferencesInnerView: View {
       Label("Resume Reading Progress", systemImage: "clock.arrow.circlepath")
     }.disableWithPlusCheck(.resumeProgress)
 
+    Toggle(isOn: $pref.hideNotificationToolbarShortcut) {
+      Label("Hide Notification Shortcut", systemImage: "bell.slash")
+    }
+
     Toggle(isOn: $pref.useInAppSafari) {
       Label("Always Use In-App Safari", systemImage: "safari")
     }


### PR DESCRIPTION
## Summary
- add a persisted preference for hiding the notification toolbar shortcut
- expose the toggle in Settings > Reading
- suppress `NotificationToolbarItem` centrally when the preference is enabled
- add zh-Hans localization for the new setting

## Verification
- make swiftformat
- make build