### PR TITLE
fix: normalize tag names to lowercase for case-insensitive matching

### DIFF
--- a/logic/text/src/content.rs
+++ b/logic/text/src/content.rs
@@ -60,7 +60,7 @@ peg::parser! {
                 let complex_attributes = complex_attributes.into_iter().map(|s| s.to_owned()).collect();
 
                 Ok(span_of!(tagged(Span_Tagged {
-                    tag: start_tag.to_owned(),
+                    tag: start_tag.to_ascii_lowercase(),
                     attributes,
                     complex_attributes,
                     spans: s.into(),
@@ -398,6 +398,20 @@ size=百分比]
             let r = do_parse_content(text).unwrap();
             println!("{:#?}", r);
         }
+    }
+
+    #[test]
+    fn test_uppercase_tags_normalized() {
+        let text = r#"[DEL]deleted[/DEL] [B]bold[/B] [Quote]quoted[/Quote] [DEL]mixed[/del]"#;
+        let r = do_parse_content(text).unwrap();
+        let tags: Vec<&str> = r
+            .iter()
+            .filter_map(|span| match span.value.as_ref() {
+                Some(Span_oneof_value::tagged(tagged)) => Some(tagged.tag.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tags, vec!["del", "b", "quote", "del"]);
     }
 
     fn span_tag_depth(span: &Span) -> usize {


### PR DESCRIPTION
## Summary
- Uppercase BBCode tags like `[DEL][/DEL]` or mixed-case `[DEL][/del]` were not rendered correctly — they fell through to the default branch and displayed as plain text.
- Root cause: the Rust parser preserved original tag case, while the Swift renderer (`ContentCombiner.swift`) only matched lowercase names in its switch statement.
- Fix: normalize tag names to lowercase at parse time with `to_ascii_lowercase()` in `content.rs`.

## Test plan
- [x] Added `test_uppercase_tags_normalized` covering all-uppercase, mixed-case, and mismatched open/close tag cases
- [x] All 21 existing text crate tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)