### PR TITLE
fix: share pure URLs for NGA and MNGA links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,5 +121,5 @@ You can use the `AXe` CLI for iOS Simulator automation to conduct end-to-end tes
 - Prefer selector-based taps, but bottom bars, overlays, and duplicate labels can make coordinate taps necessary.
 - AXe can be unreliable when toggling SwiftUI switches. After tapping a `Toggle`, re-check its `AXValue`; if it does not change, fall back to tapping the actual switch control, or verify behavior through the same persisted setting in the simulator container.
 - In MNGA, the accessibility tree is good enough for navigation and screen-state confirmation.
-- Prefer deep links like `mnga://topic/<tid>` when a known topic must be opened quickly.
+- Prefer deep links like `mnga://topic/<tid>` when a known topic must be opened quickly.For testing purposes, you can use the well-known topic ID `45150945` to evaluate general functionality.
 - If you need to rotate the simulator from the terminal, `osascript` can click Simulator menu items such as `Device > Rotate Left/Right`, but this requires macOS Accessibility permission for the terminal process first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,5 +121,5 @@ You can use the `AXe` CLI for iOS Simulator automation to conduct end-to-end tes
 - Prefer selector-based taps, but bottom bars, overlays, and duplicate labels can make coordinate taps necessary.
 - AXe can be unreliable when toggling SwiftUI switches. After tapping a `Toggle`, re-check its `AXValue`; if it does not change, fall back to tapping the actual switch control, or verify behavior through the same persisted setting in the simulator container.
 - In MNGA, the accessibility tree is good enough for navigation and screen-state confirmation.
-- Prefer deep links like `mnga://topic/<tid>` when a known topic must be opened quickly.For testing purposes, you can use the well-known topic ID `45150945` to evaluate general functionality.
+- Prefer deep links like `mnga://topic/<tid>` when a known topic must be opened quickly.
 - If you need to rotate the simulator from the terminal, `osascript` can click Simulator menu items such as `Device > Rotate Left/Right`, but this requires macOS Accessibility permission for the terminal process first.

--- a/app/Shared/Views/ShareLinksView.swift
+++ b/app/Shared/Views/ShareLinksView.swift
@@ -40,26 +40,14 @@ struct ShareLinksView<V: View>: View {
   var body: some View {
     Menu {
       if let mngaURL = navigationID.mngaURL {
-        if let title = prefixedShareTitle("MNGA - ") {
-          ShareLink(item: mngaURL, message: Text(title)) {
-            Label("MNGA Link", systemImage: "m.circle")
-          }
-        } else {
-          ShareLink(item: mngaURL) {
-            Label("MNGA Link", systemImage: "m.circle")
-          }
+        ShareLink(item: mngaURL) {
+          Label("MNGA Link", systemImage: "m.circle")
         }
       }
 
       if let webpageURL = navigationID.webpageURL {
-        if let title = prefixedShareTitle("NGA - ") {
-          ShareLink(item: webpageURL, message: Text(title)) {
-            Label("NGA Link", systemImage: "network")
-          }
-        } else {
-          ShareLink(item: webpageURL) {
-            Label("NGA Link", systemImage: "network")
-          }
+        ShareLink(item: webpageURL) {
+          Label("NGA Link", systemImage: "network")
         }
       }
 


### PR DESCRIPTION
## Summary
- remove share titles from the `ShareLink` payload for NGA and MNGA links
- share the raw URL only so system Copy returns a URL and third-party apps like WeChat keep accepting the share

## Testing
- not run (validated manually in the simulator earlier during debugging)