### PR TITLE
feat: quick save image to photos on long press

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -383,3 +383,10 @@
 "Pink" = "粉色";
 "Brown" = "棕色";
 "Gray" = "灰色";
+
+"Quick Save Image on Long Press" = "长按图片快速保存";
+"Save to Photos" = "保存到相册";
+"View Image" = "查看图片";
+"Saved" = "已保存";
+"Save Failed" = "保存失败";
+"No Photo Library Permission" = "没有相册权限";

--- a/app/Shared/Storage/PreferencesStorage.swift
+++ b/app/Shared/Storage/PreferencesStorage.swift
@@ -59,6 +59,7 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("autoOpenInBrowserWhenBannedNew") var autoOpenInBrowserWhenBanned = false
   @AppStorage("topicDetailsWebApiStrategyNew") var topicDetailsWebApiStrategy = TopicDetailsRequest.WebApiStrategy.secondary
   @AppStorage("alwaysShareImageAsFile") var alwaysShareImageAsFile = false
+  @AppStorage("quickSaveImage") var quickSaveImage = false
 
   // MARK: - Debug
 

--- a/app/Shared/Views/ContentImageView.swift
+++ b/app/Shared/Views/ContentImageView.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Photos
 import SDWebImageSwiftUI
 import SwiftUI
 import SwiftUIX
@@ -65,6 +66,7 @@ struct ContentImageView: View {
   }
 
   @State var frameWidth: CGFloat? = nil
+  @State private var quickSaveDialogPresented = false
 
   var options: SDWebImageOptions {
     if inSnapshot {
@@ -104,6 +106,19 @@ struct ContentImageView: View {
         .colorMultiply(shouldDimImage ? Color(white: 0.7) : Color.white)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .onTapGesture(perform: showImage)
+        // Use a high-priority long press so the image can present its own quick
+        // actions instead of being swallowed by the post-level `.contextMenu`.
+        // The gesture mask disables it when the preference is off, leaving the
+        // post-level context menu intact. Avoid `.if()` here to keep WebImage state.
+        .highPriorityGesture(
+          LongPressGesture(minimumDuration: 0.4)
+            .onEnded { _ in quickSaveDialogPresented = true },
+          including: prefs.quickSaveImage && inRealPost ? .all : .none,
+        )
+        .confirmationDialog("Image", isPresented: $quickSaveDialogPresented, titleVisibility: .hidden) {
+          Button("Save to Photos") { saveImageToPhotos() }
+          Button("View Image") { showImage() }
+        }
       }
     }
   }
@@ -115,6 +130,41 @@ struct ContentImageView: View {
       viewingImage.show(urls: model.allImageURLs, current: attachURL)
     } else {
       viewingImage.show(url: url)
+    }
+  }
+
+  func saveImageToPhotos() {
+    SDWebImageManager.shared.loadImage(with: url, options: [], progress: nil) { image, data, _, _, _, _ in
+      guard let image else {
+        ToastModel.showAuto(.error("Save Failed"))
+        return
+      }
+      PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+        guard status == .authorized || status == .limited else {
+          DispatchQueue.main.async {
+            ToastModel.showAuto(.error("No Photo Library Permission"))
+          }
+          return
+        }
+        PHPhotoLibrary.shared().performChanges {
+          if let data {
+            let options = PHAssetResourceCreationOptions()
+            options.originalFilename = url.lastPathComponent
+            let request = PHAssetCreationRequest.forAsset()
+            request.addResource(with: .photo, data: data, options: options)
+          } else {
+            PHAssetChangeRequest.creationRequestForAsset(from: image)
+          }
+        } completionHandler: { success, _ in
+          DispatchQueue.main.async {
+            if success {
+              ToastModel.showAuto(.success("Saved"))
+            } else {
+              ToastModel.showAuto(.error("Save Failed"))
+            }
+          }
+        }
+      }
     }
   }
 

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -79,6 +79,9 @@ private struct PostRowAppearanceView: View {
           Label("Dim Images in Dark Mode", systemImage: "moon.fill")
         }
         .disableWithPlusCheck(.customAppearance)
+        Toggle(isOn: $pref.quickSaveImage.animation()) {
+          Label("Quick Save Image on Long Press", systemImage: "square.and.arrow.down")
+        }
       }
 
     }.pickerStyle(.menu)


### PR DESCRIPTION
## What

Add an **opt-in** "Quick Save Image on Long Press" setting. When enabled,
long-pressing an image inside a post shows a quick action menu to **save the
image directly to the photo library** (or view it), instead of going through
*Select Attachments → tap image → save*.

The setting lives under **Settings → Appearance → Post** and is **off by
default**, so existing long-press behavior (the post-level context menu) is
unchanged unless the user opts in.

## How

- `ContentImageView` gains a `saveImageToPhotos()` that reuses
  `SDWebImageManager`'s cached data, so the **original (non-thumbnail)** image is
  saved, and requests add-only Photos permission before writing.
- The image uses a **high-priority** `LongPressGesture` that presents a
  `confirmationDialog`. This is needed because the image lives inside the
  post-level `.contextMenu` subtree; without a high-priority gesture the image's
  own actions get swallowed by the post context menu. The gesture's mask is set
  to `.none` when the setting is off (or outside a real post), so it doesn't
  interfere with the existing context menu at all in the default configuration.

## Screenshots

| Setting | Long-press menu |
|---|---|
| ![setting](https://raw.githubusercontent.com/mufanq/MNGA/assets/pr-screenshots/screenshots/quick-save-settings.jpg) | ![menu](https://raw.githubusercontent.com/mufanq/MNGA/assets/pr-screenshots/screenshots/quick-save-menu.jpg) |

## Testing

- Built and ran on the iOS Simulator and on a physical device.
- Verified: with the setting on, long-pressing an image shows Save / View and
  saving writes the full-size image to Photos; with the setting off, the normal
  post context menu appears as before.
