### PR TITLE
feat: optimistic vote updates

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "Send" = "发送";
 "Quote" = "引用";
 "Vote Up" = "点赞";
+"Vote Failed" = "操作失败";
 "Edit" = "编辑";
 "Edit Signature" = "修改签名";
 "Share" = "分享";

--- a/app/Shared/Models/VotesModel.swift
+++ b/app/Shared/Models/VotesModel.swift
@@ -12,6 +12,29 @@ import SwiftUI
 class VotesModel: ObservableObject {
   typealias Vote = (state: VoteState, delta: Int32)
 
+  /// Predict the resulting vote after applying `operation`, mirroring NGA's
+  /// toggle semantics so optimistic updates match what the server returns:
+  /// tapping the current state again clears it; switching across up/down moves
+  /// by 2. Used to update the UI instantly before the network round-trip.
+  static func predictVote(from current: Vote, operation: PostVoteRequest.Operation) -> Vote {
+    switch (operation, current.state) {
+    case (.upvote, .up): // toggle off
+      return (state: .none, delta: current.delta - 1)
+    case (.upvote, .down): // flip down -> up
+      return (state: .up, delta: current.delta + 2)
+    case (.upvote, _): // none -> up
+      return (state: .up, delta: current.delta + 1)
+    case (.downvote, .down): // toggle off
+      return (state: .none, delta: current.delta + 1)
+    case (.downvote, .up): // flip up -> down
+      return (state: .down, delta: current.delta - 2)
+    case (.downvote, _): // none -> down
+      return (state: .down, delta: current.delta - 1)
+    default: // unknown operation (e.g. UNRECOGNIZED): no change
+      return current
+    }
+  }
+
   // TODO: check performance cost here
   @Published private var votes = [PostId: Vote]()
 

--- a/app/Shared/Views/PostRowView.swift
+++ b/app/Shared/Views/PostRowView.swift
@@ -367,23 +367,38 @@ struct PostRowView: View {
       return
     }
 
+    // Optimistically update the UI immediately, then send the request in the
+    // background and reconcile with the server's authoritative result. On
+    // failure, roll back to the previous state.
+    let previous = vote
+    let predicted = VotesModel.predictVote(from: previous, operation: operation)
+
+    withAnimation {
+      vote = predicted
+      #if os(iOS)
+        if vote.state != .none {
+          HapticUtils.play(style: .light)
+        }
+      #endif
+    }
+
     logicCallAsync(.postVote(.with {
       $0.postID = post.id
       $0.operation = operation
-    })) { (response: PostVoteResponse) in
+    }), errorToastModel: nil) { (response: PostVoteResponse) in
       if !response.hasError {
+        // Reconcile delta against the pre-vote baseline so the server value wins
+        // regardless of our prediction.
         withAnimation {
           vote.state = response.state
-          vote.delta += response.delta
-          #if os(iOS)
-            if vote.state != .none {
-              HapticUtils.play(style: .light)
-            }
-          #endif
+          vote.delta = previous.delta + response.delta
         }
       } else {
-        // not used
+        withAnimation { vote = previous }
       }
+    } onError: { _ in
+      withAnimation { vote = previous }
+      ToastModel.showAuto(.error("Vote Failed"))
     }
   }
 


### PR DESCRIPTION
## What

Make voting feel instant. Currently tapping upvote/downvote waits for the full
network round-trip before the UI reflects the change, so there's a noticeable
delay between the tap and the score/icon updating. This switches voting to an
**optimistic update**: the state and score change immediately on tap, the
request is sent in the background, and the result is reconciled with the server
(rolling back on failure).

## How

- A pure `VotesModel.predictVote(from:operation:)` mirrors NGA's toggle
  semantics so the optimistic value matches what the server returns:
  - tapping the current direction again clears the vote (`UP` + upvote → `NONE`, −1),
  - flipping across directions moves the score by 2 (`DOWN` + upvote → `UP`, +2),
  - voting from neutral moves by 1.
- `PostRowView.doVote` now applies the prediction immediately (with the existing
  haptic), then sends `postVote` in the background. On success it reconciles the
  score against the **pre-vote baseline** using the server's authoritative
  `state`/`delta`, so the server always wins regardless of the prediction. On
  failure it restores the previous state and shows an error toast.

The prediction table was cross-checked against the existing Rust `post_vote`
test sequence (`logic/service/src/post.rs`) and matches it case-for-case, so the
optimistic value and the server result agree (no score flicker).

## Testing

- Built and ran on the iOS Simulator and a physical device.
- Verified: tapping votes updates instantly; re-tapping toggles off; flipping
  up↔down moves the score by 2 with no intermediate flicker; the score settles
  to the server value.
