### PR TITLE
feat: optionally open cached topics instantly

### DIFF
--- a/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -314,6 +314,7 @@
 "Unnamed Folder" = "未命名的收藏夹";
 "Add to New Folder" = "添加到新收藏夹";
 "Resume Reading Progress" = "恢复阅读进度";
+"Open Cached Topics Instantly" = "秒开已缓存的帖子";
 "Refresh Button" = "刷新按钮";
 "Blocked Topics Style" = "屏蔽话题样式";
 "Redact Subject" = "遮盖标题";

--- a/app/Shared/Models/PagingDataSource.swift
+++ b/app/Shared/Models/PagingDataSource.swift
@@ -202,6 +202,24 @@ class PagingDataSource<Res: SwiftProtobuf.Message, Item>: ObservableObject {
     }
   }
 
+  /// Populate the source from an already-fetched response (e.g. a synchronous
+  /// local-cache read) without issuing a network request, so the content shows
+  /// instantly. Marks the page as loaded so a subsequent `initialLoad()` is a
+  /// no-op. Returns whether any item was populated.
+  @discardableResult
+  func injectCachedResponse(_ response: Res, page: Int) -> Bool {
+    let (newItems, newTotalPages) = onResponse(response)
+    guard !newItems.isEmpty else { return false }
+
+    latestResponse = response
+    latestError = nil
+    replaceItems(newItems, page: page)
+    totalPages = newTotalPages ?? totalPages
+    loadedPage = page
+    lastRefreshTime = Date()
+    return true
+  }
+
   func reloadLastPage(
     evenIfNotLoaded: Bool,
     animated: Bool = true,

--- a/app/Shared/Storage/PreferencesStorage.swift
+++ b/app/Shared/Storage/PreferencesStorage.swift
@@ -59,6 +59,7 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("autoOpenInBrowserWhenBannedNew") var autoOpenInBrowserWhenBanned = false
   @AppStorage("topicDetailsWebApiStrategyNew") var topicDetailsWebApiStrategy = TopicDetailsRequest.WebApiStrategy.secondary
   @AppStorage("alwaysShareImageAsFile") var alwaysShareImageAsFile = false
+  @AppStorage("topicDetailsCacheFirst") var topicDetailsCacheFirst = false
 
   // MARK: - Debug
 

--- a/app/Shared/Views/PreferencesView.swift
+++ b/app/Shared/Views/PreferencesView.swift
@@ -243,6 +243,10 @@ struct PreferencesInnerView: View {
       Label("Resume Reading Progress", systemImage: "clock.arrow.circlepath")
     }.disableWithPlusCheck(.resumeProgress)
 
+    Toggle(isOn: $pref.topicDetailsCacheFirst) {
+      Label("Open Cached Topics Instantly", systemImage: "bolt")
+    }
+
     Toggle(isOn: $pref.hideNotificationToolbarShortcut) {
       Label("Hide Notification Shortcut", systemImage: "bell.slash")
     }

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -861,6 +861,11 @@ struct TopicDetailsView: View {
       return
     }
 
+    // `onAppear` fires again whenever a pushed view is popped back from; only
+    // the very first one may inject the cache, or we would wipe the pages
+    // loaded since then (like `initialLoad`, which is a no-op once loaded).
+    guard dataSource.notLoaded else { return }
+
     // 1. Read the local cache first (no network on the Rust side, so this is
     //    fast) to show content instantly.
     let cacheRequest = TopicDetailsRequest.with {

--- a/app/Shared/Views/TopicDetailsView.swift
+++ b/app/Shared/Views/TopicDetailsView.swift
@@ -832,12 +832,77 @@ struct TopicDetailsView: View {
       }
     }
     .mayGroupedListStyle()
-    .onAppear { dataSource.initialLoad() }
+    .onAppear { onInitialAppear() }
     .onChange(of: dataSource.latestResponse) { updateTopicOnNewResponse(response: $1) }
   }
 
   var maxFloor: Int {
     Int((dataSource.latestResponse?.topic ?? topic).repliesNum)
+  }
+
+  /// Whether the cache-first fast path applies: only for a plain first-page
+  /// browse (the case that has a cache key on the Rust side), and only when the
+  /// user opted in. Jump-to-floor / only-post / author-only / local mode are
+  /// excluded because they don't share that cache.
+  var cacheFirstApplicable: Bool {
+    prefs.topicDetailsCacheFirst
+      && !previewMode
+      && !forceLocalMode
+      && !mock
+      && onlyPost.id == nil
+      && postIdToJump == nil
+      && floorToJump == nil
+      && !topic.id.isEmpty
+  }
+
+  func onInitialAppear() {
+    guard cacheFirstApplicable else {
+      dataSource.initialLoad()
+      return
+    }
+
+    // 1. Read the local cache first (no network on the Rust side, so this is
+    //    fast) to show content instantly.
+    let cacheRequest = TopicDetailsRequest.with {
+      $0.topicID = topic.id
+      if topic.hasFav { $0.fav = topic.fav }
+      $0.localCache = true
+      $0.page = 1
+    }
+    logicCallAsync(.topicDetails(cacheRequest), errorToastModel: nil) { (cached: TopicDetailsResponse) in
+      // `injectCachedResponse` sets `latestResponse`, which drives
+      // `updateTopicOnNewResponse` via the existing `.onChange` in `body`.
+      let shown = dataSource.injectCachedResponse(cached, page: 1)
+      if shown {
+        // 2. Silently refresh the cache in the background for next time. The
+        //    response is discarded on purpose so the current view isn't replaced.
+        refreshCacheInBackground()
+      } else {
+        dataSource.initialLoad()
+      }
+    } onError: { _ in
+      // Cache miss (no local cache): fall back to the normal network load,
+      // which also writes the cache for next time.
+      dataSource.initialLoad()
+    }
+  }
+
+  /// Fire a network request whose only effect is updating the on-disk cache
+  /// (the Rust service writes the cache on every successful load). The response
+  /// is intentionally ignored so the visible content stays stable.
+  func refreshCacheInBackground() {
+    let request = TopicDetailsRequest.with {
+      $0.webApiStrategy = prefs.topicDetailsWebApiStrategy
+      $0.topicID = topic.id
+      if topic.hasFav { $0.fav = topic.fav }
+      $0.localCache = false
+      $0.page = 1
+    }
+    logicCallAsync(.topicDetails(request), errorToastModel: nil) { (_: TopicDetailsResponse) in
+      // Discard: the cache has been refreshed on the Rust side for next time.
+    } onError: { _ in
+      // Silent: stale cache remains usable until a later refresh succeeds.
+    }
   }
 
   func mayScrollToJumpFloor() {


### PR DESCRIPTION
## What

Make opening a previously-read topic feel instant. Currently every time you
open a topic the details are re-fetched over the network before anything shows,
so even topics you just read have a visible delay. This adds an **opt-in**
"Open Cached Topics Instantly" setting (off by default, under Reading) that
shows the on-disk cache immediately, then silently refreshes the cache in the
background for next time.

## How

The Rust service already writes the topic-details cache on every successful
load and already supports a `local_cache` request flag that returns the cache
without hitting the network. This change wires those together on the Swift side:

- `PagingDataSource.injectCachedResponse(_:page:)` populates items from an
  already-fetched response without a network round-trip.
- `TopicDetailsView` orchestrates two stages on appear: first a `local_cache`
  read shows content instantly; then it fires a normal background load whose
  only effect is refreshing the cache (the response is discarded so the current
  view isn't replaced — no scroll jumps or flicker). On a cache miss it falls
  back to the normal load, so first-time opens behave exactly as before.
- Only applies to a plain first-page browse (the case that has a cache key);
  jump-to-floor / only-post / author-only / local mode are excluded.

Pull-to-refresh still fetches live content on demand. No proto or Rust changes.

## Testing

- Built and ran on the iOS Simulator and a physical device.
- Verified: with the setting on, re-opening a read topic shows instantly and
  the cache is refreshed in the background for the next visit; first-time opens
  and pull-to-refresh are unchanged; jump-to-floor/only-post paths unaffected.
