### PR TITLE
fix: migrate default NGA backend

### DIFF
--- a/.github/workflows/ios_debug.yaml
+++ b/.github/workflows/ios_debug.yaml
@@ -29,10 +29,12 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26"
+      - uses: jdx/mise-action@v4
+        with:
+          tool_versions: tuist 4.131.1
       - name: Install Prereqs
         run: |
           brew install swift-protobuf
-          brew install --formula tuist@4.131.1
       - name: Build Logic (Debug, iOS)
         run: make logic ALL_TARGETS="aarch64-apple-ios" MODE=debug
         env:

--- a/.github/workflows/ios_debug.yaml
+++ b/.github/workflows/ios_debug.yaml
@@ -32,7 +32,6 @@ jobs:
       - name: Install Prereqs
         run: |
           brew install swift-protobuf
-          brew tap tuist/tuist
           brew install --formula tuist@4.131.1
       - name: Build Logic (Debug, iOS)
         run: make logic ALL_TARGETS="aarch64-apple-ios" MODE=debug

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
       - name: Install Prereqs
         run: |
           brew install swift-protobuf
-          brew tap tuist/tuist
           brew install --formula tuist@4.131.1
       - name: Build Logic for Deployment
         run: make logic-deploy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,12 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26"
+      - uses: jdx/mise-action@v4
+        with:
+          tool_versions: tuist 4.131.1
       - name: Install Prereqs
         run: |
           brew install swift-protobuf
-          brew install --formula tuist@4.131.1
       - name: Build Logic for Deployment
         run: make logic-deploy
         env:

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -68,7 +68,7 @@ let project = Project(
             settings: .settings(
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "MNGA",
-                    "MARKETING_VERSION": "2.3",
+                    "MARKETING_VERSION": "2.3.1",
                     "CURRENT_PROJECT_VERSION": "1",
                     "SWIFT_VERSION": "5.0",
                     "ENABLE_BITCODE": "NO",

--- a/app/Shared/Storage/PreferencesStorage.swift
+++ b/app/Shared/Storage/PreferencesStorage.swift
@@ -11,6 +11,15 @@ import SwiftUI
 import SwiftUIX
 
 let alwaysPortraitOnPhonePreferenceKey = "alwaysPortraitOnPhone"
+private let legacyBackendBaseURLs: Set<String> = ["https://nga.178.com", "https://nga.178.com/"]
+
+private extension RequestOption {
+  mutating func migrateBackendIfNeeded() {
+    if baseURLV2.isEmpty || legacyBackendBaseURLs.contains(baseURLV2) {
+      baseURLV2 = URLs.defaultBase.absoluteString
+    }
+  }
+}
 
 class PreferencesStorage: ObservableObject {
   @Published var showing = false
@@ -67,6 +76,10 @@ class PreferencesStorage: ObservableObject {
   @AppStorage("debugAlwaysShowNotificationBadge") var debugAlwaysShowNotificationBadge = false
 
   init() {
+    var option = requestOptionWrapper.inner
+    option.migrateBackendIfNeeded()
+    requestOptionWrapper.inner = option
+
     syncRequestOptionWithLogic()
   }
 

--- a/app/Shared/Utilities/URLs.swift
+++ b/app/Shared/Utilities/URLs.swift
@@ -10,8 +10,8 @@ import Foundation
 enum URLs {
   static let attachmentBase = URL(string: "https://img.nga.178.com/attachments/")!
 
-  static let defaultHost = "nga.178.com"
-  static let hosts = [defaultHost, "bbs.nga.cn", "ngabbs.com"]
+  static let defaultHost = "bbs.nga.cn"
+  static let hosts = [defaultHost, "ngabbs.com", "bbs.ngacn.cc"]
 
   static func base(for host: String) -> URL? {
     URL(string: "https://\(host)/")

--- a/app/Shared/Utilities/WhatsNew.swift
+++ b/app/Shared/Utilities/WhatsNew.swift
@@ -139,8 +139,8 @@ struct MNGAWhatsNew: WhatsNewCollectionProvider {
     )
 
     WhatsNew(
-      version: "2.3",
-      title: whatsNewTitle(version: "2.3"),
+      version: "2.3.1",
+      title: whatsNewTitle(version: "2.3.1"),
       features: [
         .init(
           image: .init(systemName: "photo"),

--- a/logic/service/src/constants.rs
+++ b/logic/service/src/constants.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-pub const DEFAULT_BASE_URL: &str = "https://nga.178.com";
+pub const DEFAULT_BASE_URL: &str = "https://bbs.nga.cn";
 pub const DEFAULT_MOCK_BASE_URL: &str = "https://mnga-pages.bugenzhao.com/api/";
 pub const DEFAULT_PROXY_BASE_URL: &str = "https://nga.bugenzhao.com";
 pub const FORUM_ICON_PATH: &str = "http://img4.ngacn.cc/ngabbs/nga_classic/f/app/";

--- a/logic/service/src/request.rs
+++ b/logic/service/src/request.rs
@@ -4,6 +4,16 @@ use std::sync::RwLock;
 
 use crate::constants::DEFAULT_BASE_URL;
 
+const LEGACY_BASE_URLS: &[&str] = &["https://nga.178.com", "https://nga.178.com/"];
+
+fn normalize_base_url(base_url: &str) -> String {
+    if base_url.is_empty() || LEGACY_BASE_URLS.contains(&base_url) {
+        DEFAULT_BASE_URL.to_owned()
+    } else {
+        base_url.to_owned()
+    }
+}
+
 fn default_request_option() -> RequestOption {
     RequestOption {
         base_url_v2: DEFAULT_BASE_URL.to_owned(),
@@ -18,8 +28,22 @@ lazy_static! {
 }
 
 pub fn set_request_option(mut option: RequestOption) {
-    if option.get_base_url_v2().is_empty() {
-        option.set_base_url_v2(DEFAULT_BASE_URL.to_owned());
-    }
+    option.set_base_url_v2(normalize_base_url(option.get_base_url_v2()));
     *REQUEST_OPTION.write().unwrap() = option;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_normalize_base_url() {
+        assert_eq!(normalize_base_url(""), DEFAULT_BASE_URL);
+        assert_eq!(normalize_base_url("https://nga.178.com"), DEFAULT_BASE_URL);
+        assert_eq!(normalize_base_url("https://nga.178.com/"), DEFAULT_BASE_URL);
+        assert_eq!(
+            normalize_base_url("https://ngabbs.com"),
+            "https://ngabbs.com"
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- Change the default NGA backend from `nga.178.com` to `bbs.nga.cn` in Rust logic and Swift URL defaults.
- Migrate persisted empty or legacy `https://nga.178.com` backend settings to the new default.
- Update backend picker options to prefer currently working NGA hosts.

## Why

`nga.178.com` now redirects API traffic to `bbs.nga.cn`. MNGA sends auth through POST form fields, and the redirect path can lose those fields before the request reaches the final host, causing NGA to report `未登录` or request errors.

## Validation

- `cargo fmt`
- `cargo test -p service request::test::test_normalize_base_url -- --exact`
- `cargo test -p service test_topic_list -- --ignored --nocapture`
- `cargo clippy`
