### PR TITLE
fix: inject environment objects into settings sheet

### DIFF
--- a/app/Shared/ContentView.swift
+++ b/app/Shared/ContentView.swift
@@ -120,6 +120,7 @@ struct GlobalSheetsModifier: ViewModifier {
   @EnvironmentObject var userSignaturePost: UserSignaturePostModel
   @EnvironmentObject var textSelection: TextSelectionModel
   @EnvironmentObject var viewingImage: ViewingImageModel
+  @EnvironmentObject var paywall: PaywallModel
   @StateObject var prefs = PreferencesStorage.shared
 
   func body(content: Content) -> some View {
@@ -128,7 +129,12 @@ struct GlobalSheetsModifier: ViewModifier {
       .sheet(isPresented: $shortMessagePost.showEditor) { ShortMessageEditorView() }
       .sheet(isPresented: $userSignaturePost.showEditor) { UserSignatureEditorView() }
       .sheet(isPresented: $textSelection.text.isNotNil()) { TextSelectionView().presentationDetents([.medium, .large]) }
-      .sheet(isPresented: $prefs.showing) { PreferencesView() }
+      .sheet(isPresented: $prefs.showing) {
+        PreferencesView()
+          .environmentObject(paywall)
+          .environmentObject(textSelection)
+          .environmentObject(viewingImage)
+      }
       .modifier(PaywallSheetModifier())
       .fullScreenCover(isPresented: $viewingImage.showing) { NewImageViewer() }
   }


### PR DESCRIPTION
## Summary

- explicitly pass `PaywallModel`, `TextSelectionModel`, and `ViewingImageModel` to the settings sheet
- prevent missing `@EnvironmentObject` assertions when opening Settings and Topic Details Style on Mac (Designed for iPad)

## Context

A crash report from MNGA 2.3 (123) shows `EnvironmentObject.error()` while SwiftUI is constructing a `Form`. The settings sheet is presented before the global environment-object modifiers, and sheets have previously required explicit injection on Apple silicon Macs.

## Testing

- built the My Mac (Designed for iPad) target with Xcode 26.6 and `CODE_SIGNING_ALLOWED=NO`
- built and launched the iPad (A16) simulator target on iOS 26.5
- navigated through Settings to Topic Details Style with AXe and confirmed both forms render without a crash