### PR TITLE
fix: migrate NGA image hosts

### DIFF
--- a/app/Shared/Models/AttachmentsModel.swift
+++ b/app/Shared/Models/AttachmentsModel.swift
@@ -16,14 +16,14 @@ class AttachmentsModel: ObservableObject {
   }
 
   func attachmentURL(for previewURL: URL) -> URL? {
-    guard let attach = items.first(where: { previewURL.absoluteString.contains($0.url) })
-    else { return nil }
-    return URL(string: attach.url, relativeTo: URLs.attachmentBase)
+    items
+      .compactMap { URLs.attachmentURL($0.url) }
+      .first(where: { $0 == previewURL })
   }
 
   var allImageURLs: [URL] {
     items
       .filter(\.isImage)
-      .compactMap { URL(string: $0.url, relativeTo: URLs.attachmentBase) }
+      .compactMap { URLs.attachmentURL($0.url) }
   }
 }

--- a/app/Shared/Protos/Extensions.swift
+++ b/app/Shared/Protos/Extensions.swift
@@ -370,7 +370,7 @@ extension User {
       $0.postNum = 2333
       $0.regDate = 1_609_502_400
       $0.signature = signatureRes?.content ?? .init()
-      $0.avatarURL = "https://img.nga.178.com/avatars/2002/03a/000/000/58_0.jpg"
+      $0.avatarURL = "https://img.nga.cn/avatars/2002/03a/000/000/58_0.jpg"
     }
   }
 }

--- a/app/Shared/Utilities/ContentCombiner.swift
+++ b/app/Shared/Utilities/ContentCombiner.swift
@@ -546,7 +546,7 @@ class ContentCombiner {
     guard case let .plain(plain) = value else { return }
 
     let urlText = plain.text.trimmingWs
-    guard let url = URL(string: urlText, relativeTo: URLs.attachmentBase) else { return }
+    guard let url = URLs.attachmentURL(urlText) else { return }
     if url.pathExtension == "mp4" {
       return visitFlash(video: image)
     }
@@ -586,7 +586,7 @@ class ContentCombiner {
 
     // Construct the URL
     let p = String(format: "mon_%04d%02d/%02d/", year, month, day)
-    guard let url = URL(string: p + urlText, relativeTo: URLs.attachmentBase) else { return }
+    guard let url = URLs.attachmentURL(p + urlText) else { return }
     if url.pathExtension == "mp4" {
       return visitFlash(video: noimg)
     }
@@ -847,7 +847,7 @@ class ContentCombiner {
     guard case let .plain(plain) = value else { return }
 
     let urlText = plain.text.trimmingWs
-    guard let url = URL(string: urlText, relativeTo: URLs.attachmentBase) else { return }
+    guard let url = URLs.attachmentURL(urlText) else { return }
 
     let link = ContentButtonView(icon: "film", title: Text("View Video"), inQuote: inQuote) {
       OpenURLModel.shared.open(url: url, inApp: true)
@@ -863,7 +863,7 @@ class ContentCombiner {
     let duration = tokens.last { $0.contains("duration") }
 
     guard let urlText = tokens.first else { return }
-    guard let url = URL(string: urlText.trimmingWs, relativeTo: URLs.attachmentBase) else { return }
+    guard let url = URLs.attachmentURL(urlText.trimmingWs) else { return }
 
     let title = if let duration = extractQueryParams(query: duration ?? "", param: "duration") {
       Text(duration)
@@ -882,7 +882,7 @@ class ContentCombiner {
     guard case let .plain(plain) = value else { return }
 
     let urlText = plain.text.trimmingWs
-    guard let url = URL(string: urlText, relativeTo: URLs.attachmentBase) else { return }
+    guard let url = URLs.attachmentURL(urlText) else { return }
 
     let link = ContentButtonView(icon: "paperclip", title: Text("View Attachment"), inQuote: inQuote) {
       OpenURLModel.shared.open(url: url, inApp: true)

--- a/app/Shared/Utilities/URLs.swift
+++ b/app/Shared/Utilities/URLs.swift
@@ -8,7 +8,31 @@
 import Foundation
 
 enum URLs {
-  static let attachmentBase = URL(string: "https://img.nga.178.com/attachments/")!
+  static let attachmentBase = URL(string: "https://img.nga.cn/attachments/")!
+
+  private static let legacyImageDomainSuffixes = [".nga.178.com", ".ngacn.cc", ".ngabbs.com"]
+
+  static func resourceURL(_ value: String, relativeTo base: URL? = nil) -> URL? {
+    guard let url = URL(string: value, relativeTo: base)?.absoluteURL,
+          var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let host = components.host?.lowercased()
+    else { return nil }
+
+    let hostParts = host.split(separator: ".", maxSplits: 1).map(String.init)
+    guard hostParts.count == 2,
+          hostParts[0].hasPrefix("img"),
+          hostParts[0].dropFirst(3).allSatisfy(\.isNumber),
+          legacyImageDomainSuffixes.contains(where: host.hasSuffix)
+    else { return url }
+
+    components.scheme = "https"
+    components.host = url.path.hasPrefix("/ngabbs/") ? "img4.nga.cn" : "img.nga.cn"
+    return components.url ?? url
+  }
+
+  static func attachmentURL(_ value: String) -> URL? {
+    resourceURL(value, relativeTo: attachmentBase)
+  }
 
   static let defaultHost = "bbs.nga.cn"
   static let hosts = [defaultHost, "ngabbs.com", "bbs.ngacn.cc"]

--- a/app/Shared/Views/AttachmentsView.swift
+++ b/app/Shared/Views/AttachmentsView.swift
@@ -42,7 +42,7 @@ struct AttachmentsView: View {
   }
 
   func show(_ attachment: Attachment) {
-    let url = URL(string: attachment.url, relativeTo: URLs.attachmentBase)
+    let url = URLs.attachmentURL(attachment.url)
     guard let url else { return }
 
     if attachment.isImage {

--- a/app/Shared/Views/ForumIconView.swift
+++ b/app/Shared/Views/ForumIconView.swift
@@ -17,12 +17,13 @@ struct ForumIconView: View {
   var body: some View {
     let defaultIcon = Image(.defaultForumIcon)
       .renderingMode(.template)
+    let url = URLs.resourceURL(iconURL)
 
-    WebImage(url: URL(string: iconURL)) {
+    WebImage(url: url) {
       ($0.image ?? defaultIcon).resizable()
     }
     .frame(width: size, height: size)
     .foregroundColor(.accentColor)
-    .id("forum-icon-\(iconURL)") // workaround not updating when url changes from nil to valid
+    .id("forum-icon-\(url?.absoluteString ?? "")") // workaround not updating when url changes from nil to valid
   }
 }

--- a/app/Shared/Views/PostContentView.swift
+++ b/app/Shared/Views/PostContentView.swift
@@ -157,7 +157,7 @@ struct PostContentView_Previews: PreviewProvider {
     let sticker2 = Span.with { $0.sticker = .with { s in s.name = "a2:doge" } }
     let sticker3 = Span.with { $0.sticker = .with { s in s.name = "pg:战斗力" } }
     let plain = Span.with { $0.plain = .with { p in p.text = "你看看他，再看看你自己。" } }
-    let imageStickerUrl = Span.with { $0.plain = .with { p in p.text = "http://img.nga.178.com/attachments/mon_201209/14/-47218_5052c104b8e27.png" } }
+    let imageStickerUrl = Span.with { $0.plain = .with { p in p.text = "https://img.nga.cn/attachments/mon_201209/14/-47218_5052c104b8e27.png" } }
     let bold = Span.with {
       $0.tagged = .with { t in
         t.tag = "b"

--- a/app/Shared/Views/TopicListView.swift
+++ b/app/Shared/Views/TopicListView.swift
@@ -384,7 +384,7 @@ struct TopicListView_Previews: PreviewProvider {
     let genshinForum = Forum.with {
       $0.id = .with { i in i.fid = "650" }
       $0.name = "原神"
-      $0.iconURL = "http://img4.nga.178.com/ngabbs/nga_classic/f/app/650.png"
+      $0.iconURL = "https://img4.nga.cn/ngabbs/nga_classic/f/app/650.png"
     }
 
     AuthedPreview {

--- a/app/Shared/Views/UserMenuView.swift
+++ b/app/Shared/Views/UserMenuView.swift
@@ -31,14 +31,15 @@ struct UserMenuView: View {
   @ViewBuilder
   var icon: some View {
     let icon = Image(systemName: authStorage.signedIn ? "person.crop.circle.fill" : "person.crop.circle")
+    let avatarURL = URLs.resourceURL(user?.avatarURL ?? "")
 
-    WebImage(url: URL(string: user?.avatarURL ?? "")) {
+    WebImage(url: avatarURL) {
       ($0.image ?? icon).resizable()
     }
     .clipShape(Circle())
     .overlay(Circle().stroke(Color.accentColor, lineWidth: 1))
     .frame(width: 24, height: 24)
-    .id("user-menu-icon-\(user?.avatarURL ?? "")") // workaround not updating when url changes from nil to valid
+    .id("user-menu-icon-\(avatarURL?.absoluteString ?? "")") // workaround not updating when url changes from nil to valid
   }
 
   @ViewBuilder

--- a/app/Shared/Views/UserView.swift
+++ b/app/Shared/Views/UserView.swift
@@ -79,7 +79,7 @@ struct UserView: View {
   }
 
   private var avatarURL: URL? {
-    URL(string: user?.avatarURL ?? "")
+    URLs.resourceURL(user?.avatarURL ?? "")
   }
 
   @ViewBuilder

--- a/logic/service/src/constants.rs
+++ b/logic/service/src/constants.rs
@@ -3,7 +3,7 @@
 pub const DEFAULT_BASE_URL: &str = "https://bbs.nga.cn";
 pub const DEFAULT_MOCK_BASE_URL: &str = "https://mnga-pages.bugenzhao.com/api/";
 pub const DEFAULT_PROXY_BASE_URL: &str = "https://nga.bugenzhao.com";
-pub const FORUM_ICON_PATH: &str = "http://img4.ngacn.cc/ngabbs/nga_classic/f/app/";
+pub const FORUM_ICON_PATH: &str = "https://img4.nga.cn/ngabbs/nga_classic/f/app/";
 pub const MNGA_ICON_PATH: &str = "https://github.com/BugenZhao/MNGA/blob/5c0e519f9064ab1d7dbfb8e14aa2a96fc7058419/assets/MNGA-round-liquid-glass-compressed.png";
 
 pub const SUCCESS_MSGS: &[&str] = &[

--- a/logic/service/src/post.rs
+++ b/logic/service/src/post.rs
@@ -623,7 +623,7 @@ mod test {
         action.set_verbatim(fetch_res.take_verbatim());
 
         let file = reqwest::get(
-            "https://img.nga.178.com/attachments/mon_201904/12/-7Q5-gr04K2iT3cSw0-k0.jpg",
+            "https://img.nga.cn/attachments/mon_201904/12/-7Q5-gr04K2iT3cSw0-k0.jpg",
         )
         .await?
         .bytes()

--- a/logic/service/src/post.rs
+++ b/logic/service/src/post.rs
@@ -622,12 +622,11 @@ mod test {
         let mut fetch_res = post_reply_fetch_content(fetch_req).await?;
         action.set_verbatim(fetch_res.take_verbatim());
 
-        let file = reqwest::get(
-            "https://img.nga.cn/attachments/mon_201904/12/-7Q5-gr04K2iT3cSw0-k0.jpg",
-        )
-        .await?
-        .bytes()
-        .await?;
+        let file =
+            reqwest::get("https://img.nga.cn/attachments/mon_201904/12/-7Q5-gr04K2iT3cSw0-k0.jpg")
+                .await?
+                .bytes()
+                .await?;
 
         let upload_req = UploadAttachmentRequest {
             action: Some(action).into(),

--- a/logic/text/src/content.rs
+++ b/logic/text/src/content.rs
@@ -156,7 +156,7 @@ mod test {
     fn test_img() {
         let text = r#"
 我们这男的还一般不让穿短裤凉鞋呢
-[img]http://img.nga.178.com/attachments/mon_201209/14/-47218_5052bc587c6f9.png[/img]
+[img]https://img.nga.cn/attachments/mon_201209/14/-47218_5052bc587c6f9.png[/img]
 虽说没有明确规定，但是理由是领导觉得影响不好，说到底还是一个形象问题吧
         "#;
         let r = do_parse_content(text).unwrap();


### PR DESCRIPTION
## What changed

- Add a centralized resource URL resolver that maps legacy NGA image hosts to `img.nga.cn` or `img4.nga.cn` based on the resource path.
- Route post media, attachments, avatars, and forum icons through the resolver while keeping backend and internal-link preferences unchanged.
- Update the forum icon service constant and network-backed fixtures to the canonical image hosts.
- Preserve third-party absolute image URLs.

## Root cause

NGA stopped resolving `img.nga.178.com`, while MNGA still used it as the fixed attachment base. The alternate backend candidates do not expose equivalent working `img.<backend>` endpoints, so image resources require canonical asset hosts independent of the selected API backend.

## User impact

Restores NGA-hosted images, attachment previews, avatars, media links, and forum icons. Historical absolute URLs using retired NGA image domains are migrated at load time.

## Validation

- `make swiftformat`
- `cargo test -p service` (9 passed, 46 ignored external-state tests)
- `cargo clippy`
- `make build` (iPhone 17 Pro, iOS 26.2 Simulator; Build Succeeded)
- Direct live probes for canonical attachment and forum icon paths returned HTTP 200

Fixes #399