### PR TITLE
chore: bump iOS version to 2.3.2

### DIFF
--- a/app/Project.swift
+++ b/app/Project.swift
@@ -68,7 +68,7 @@ let project = Project(
             settings: .settings(
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "MNGA",
-                    "MARKETING_VERSION": "2.3.1",
+                    "MARKETING_VERSION": "2.3.2",
                     "CURRENT_PROJECT_VERSION": "1",
                     "SWIFT_VERSION": "5.0",
                     "ENABLE_BITCODE": "NO",

--- a/app/Shared/Utilities/WhatsNew.swift
+++ b/app/Shared/Utilities/WhatsNew.swift
@@ -139,8 +139,8 @@ struct MNGAWhatsNew: WhatsNewCollectionProvider {
     )
 
     WhatsNew(
-      version: "2.3.1",
-      title: whatsNewTitle(version: "2.3.1"),
+      version: "2.3.2",
+      title: whatsNewTitle(version: "2.3.2"),
       features: [
         .init(
           image: .init(systemName: "photo"),


### PR DESCRIPTION
## What changed

- Bump the iOS marketing version from `2.3.1` to `2.3.2`.
- Keep the in-app What's New entry aligned with the marketing version.

## Validation

- `make swiftformat`
- `tuist generate -p app --no-open`

This prepares the merged image-host fix for the next TestFlight build.
